### PR TITLE
update mitigation strategies

### DIFF
--- a/recommendations/event-loop-readmore.md
+++ b/recommendations/event-loop-readmore.md
@@ -33,7 +33,7 @@ the bottleneck may be distributed which would take rather more detective work.
 
 ### Next Steps
 - If the system is already deployed, mitigate the issue immediately by implementing
-  HTTP 503 Service Unavailable functionality (see [Reference](#reference))
+  HTTP 503 Service Unavailable functionality (see *Load Shedding* in **Reference**)
   - This should allow the deployments Load Balance to route traffic to a different service instance
   - In the worse case the user receives the 503 in which case they must retry (this is still preferable to waiting for a timeout)
 - Use the [0x](https://www.npmjs.com/package/0x) tool to generate a flamegraph (see [Reference](#reference)).
@@ -42,11 +42,12 @@ the bottleneck may be distributed which would take rather more detective work.
 
 ### Reference
 
+- Load Shedding
+  - Express, Koa, Restify, `http`: [overload-protection](https://www.npmjs.com/package/overload-protection)
+  - Hapi: [Server load sampleInterval option](https://hapijs.com/api#new-serveroptions) & [Server connections load maxEventLoopDelay](https://hapijs.com/api#new-serveroptions)
+  - Fastify: [under-pressure](https://www.npmjs.com/package/under-pressure)
+  - General: [loopbench](https://www.npmjs.com/package/loopbench)
 - [Concurrency model and Event Loop
 ](https://developer.mozilla.org/en-US/docs/Web/JavaScript/EventLoop)
 - [Overview of Blocking vs Non-Blocking](https://nodejs.org/en/docs/guides/blocking-vs-non-blocking/)
-- Event-loop blocking detection and 503 functionality libraries
-  - Express: [loopbusy](https://www.npmjs.com/package/loopbusy)
-  - Hapi: [Server load sampleInterval option](https://hapijs.com/api#new-serveroptions) & [Server connections load maxEventLoopDelay](https://hapijs.com/api#new-serveroptions)
-  - General: [loopbench](https://www.npmjs.com/package/loopbench)
 - Understanding Flamegraphs and how to use 0x: [Tuning Node.js app performance with autocannon and 0x](https://www.nearform.com/blog/tuning-node-js-app-performance-with-autocannon-and-0x/)

--- a/recommendations/gc-readmore.md
+++ b/recommendations/gc-readmore.md
@@ -44,6 +44,8 @@ root cause behind the high memory consumption.
 
 ### Next Steps
 
+- If the system is already deployed, mitigate the issue immediately by implementing
+  HTTP 503 Service Unavailable functionality (see *Load Shedding* in **Reference**)
 - Run `node --inspect <FILENAME>`
 - Open Chrome and navigate to [chrome://inspect](chrome://inspect)
 - Under the **Remote Target** heading, there should be a target with the official Node.js icon
@@ -70,11 +72,15 @@ a core dump analysis tool to list all JS objects in a core dump file (this appro
 
 ### Reference
 
-* [Chrome Devtools Docs: Fix Memory Problems](https://developers.google.com/web/tools/chrome-devtools/memory-problems/)
-* [Chrome Devtools Docs: Memory Terminology](https://developers.google.com/web/tools/chrome-devtools/memory-problems/memory-101)
-* [Chrome Devtools Docs: How to record heap snapshots](https://developers.google.com/web/tools/chrome-devtools/memory-problems/heap-snapshots)
-
-* [Node Docs: Inspector](https://nodejs.org/en/docs/inspector/)
-* **Advanced**: [Core dump analysis tool for Linux: llnode](https://github.com/nodejs/llnode)
-* **Advanced**: [Core dump analysis tool for SmartOS: mdb_v8](https://github.com/joyent/mdb_v8)
-* **Advanced**: [Core dump analysis tool for Linux which wraps SmartOS mdb](https://www.npmjs.com/package/autopsy)
+- Load Shedding
+  - Express, Koa, Restify, `http`: [overload-protection](https://www.npmjs.com/package/overload-protection)
+  - Hapi: [Server load sampleInterval option](https://hapijs.com/api#new-serveroptions) & [Server connections load maxEventLoopDelay](https://hapijs.com/api#new-serveroptions)
+  - Fastify: [under-pressure](https://www.npmjs.com/package/under-pressure)
+  - General: [loopbench](https://www.npmjs.com/package/loopbench)
+- [Chrome Devtools Docs: Fix Memory Problems](https://developers.google.com/web/tools/chrome-devtools/memory-problems/)
+- [Chrome Devtools Docs: Memory Terminology](https://developers.google.com/web/tools/chrome-devtools/memory-problems/memory-101)
+- [Chrome Devtools Docs: How to record heap snapshots](https://developers.google.com/web/tools/chrome-devtools/memory-problems/heap-snapshots)
+- [Node Docs: Inspector](https://nodejs.org/en/docs/inspector/)
+- **Advanced**: [Core dump analysis tool for Linux: llnode](https://github.com/nodejs/llnode)
+- **Advanced**: [Core dump analysis tool for SmartOS: mdb_v8](https://github.com/joyent/mdb_v8)
+- **Advanced**: [Core dump analysis tool for Linux which wraps SmartOS mdb](https://www.npmjs.com/package/autopsy)


### PR DESCRIPTION
For Express, directs to http://npm.im/overload-protection instead of loopbusy (which has a flawed approach). Also includes additional support for Restify, Koa and core `http`. 

Updated GC issue with load shedding mitigation strategy as well

Fixes: https://github.com/nearform/node-clinic-doctor/issues/25