### PR TITLE
Flip hover

### DIFF
--- a/visualizer/hover-box.js
+++ b/visualizer/hover-box.js
@@ -9,7 +9,7 @@ class HoverBox {
     this.showen = false
     this.point = null
 
-    const size = {
+    this.size = {
       titleHeight: 36,
       lineWidth: 1,
       marginTop: 3,
@@ -18,13 +18,13 @@ class HoverBox {
       pointHeight: 10
     }
 
-    const legendTopOffset = size.titleHeight + size.lineWidth +
-                            size.marginTop
+    const legendTopOffset = this.size.titleHeight + this.size.lineWidth +
+                            this.size.marginTop
 
-    const hoverBoxHeight = legendTopOffset + size.marginBottom +
-                           this.setup.numLines * size.legendHeight
+    const hoverBoxHeight = legendTopOffset + this.size.marginBottom +
+                           this.setup.numLines * this.size.legendHeight
 
-    this.height = hoverBoxHeight + size.pointHeight
+    this.height = hoverBoxHeight + this.size.pointHeight
     this.width = 136
 
     // create main svg element
@@ -33,34 +33,34 @@ class HoverBox {
       .attr('width', this.width)
       .attr('height', this.height)
 
-    const dataBox = this.svg.append('g')
+    this.dataBox = this.svg.append('g')
       .classed('data-box', true)
 
     // create background
-    dataBox.append('rect')
+    this.dataBox.append('rect')
       .classed('background', true)
       .attr('rx', 5)
       .attr('width', this.width)
       .attr('height', hoverBoxHeight)
     this.svg.append('path')
       .classed('pointer', true)
-      .attr('d', `M${this.width / 2 - size.pointHeight} ${hoverBoxHeight} ` +
+      .attr('d', `M${this.width / 2 - this.size.pointHeight} ${hoverBoxHeight} ` +
                  `L${this.width / 2} ${this.height} ` +
-                 `L${this.width / 2 + size.pointHeight} ${hoverBoxHeight} Z`)
+                 `L${this.width / 2 + this.size.pointHeight} ${hoverBoxHeight} Z`)
     this.svg.append('path')
       .classed('pointer', true)
       .classed('below-curve', true)
-      .attr('d', `M${this.width / 2 - size.pointHeight} ${size.pointHeight} ` +
+      .attr('d', `M${this.width / 2 - this.size.pointHeight} ${this.size.pointHeight} ` +
                  `L${this.width / 2} 0 ` +
-                 `L${this.width / 2 + size.pointHeight} ${size.pointHeight} Z`)
-    dataBox.append('rect')
+                 `L${this.width / 2 + this.size.pointHeight} ${this.size.pointHeight} Z`)
+    this.dataBox.append('rect')
       .classed('line', true)
       .attr('width', this.width)
-      .attr('height', size.lineWidth)
-      .attr('y', size.titleHeight)
+      .attr('height', this.size.lineWidth)
+      .attr('y', this.size.titleHeight)
 
     // create title text
-    this.title = dataBox.append('text')
+    this.title = this.dataBox.append('text')
       .classed('title', true)
       .attr('y', 5)
       .attr('x', this.width / 2)
@@ -69,16 +69,16 @@ class HoverBox {
     // create content text
     this.values = []
     for (let i = 0; i < this.setup.numLines; i++) {
-      dataBox.append('text')
+      this.dataBox.append('text')
         .classed('legend', true)
-        .attr('y', legendTopOffset + i * size.legendHeight)
+        .attr('y', legendTopOffset + i * this.size.legendHeight)
         .attr('dy', '1em')
         .attr('x', 12)
         .text(this.setup.shortLegend[i])
 
-      const valueText = dataBox.append('text')
+      const valueText = this.dataBox.append('text')
         .classed('value', true)
-        .attr('y', legendTopOffset + i * size.legendHeight)
+        .attr('y', legendTopOffset + i * this.size.legendHeight)
         .attr('dy', '1em')
         .attr('x', 72)
       this.values.push(valueText)
@@ -94,6 +94,9 @@ class HoverBox {
     // flip down if above half way
     if (y - this.height < 0) {
       belowCurve = true
+      this.dataBox.attr('transform', `translate(0, ${this.size.pointHeight})`)
+    } else {
+      this.dataBox.attr('transform', 'translate(0, 0)')
     }
     this.svg
       .style('top', Math.round(belowCurve ? y : y - this.height) + 'px')

--- a/visualizer/style.css
+++ b/visualizer/style.css
@@ -724,10 +724,6 @@ svg#toggle-theme {
   display: none;
 }
 
-#graph .sub-graph .hover.below-curve .data-box {
-  transform: translate(0, 10px);
-}
-
 #graph .sub-graph svg.chart {
   width: 100%;
   height: 180px;


### PR DESCRIPTION
https://github.com/nearform/node-clinic-doctor/issues/40

- Initially I was hoping to simply flip with `scale(1, -1)` but then text also flipped and I facepalmed. After a few attempts to nest in a de-flip I decided to try a mathematical approach instead
- This looks the same on all screen sizes because we treat y value as quite fixed
- To achieve precision I had to pass down `hover-area` height from `SubGraph` to `HoverBox`
\* I did not manage to figure out the exact nature of `setup` constructor param as Andreas was unavailable at the time, so I have added a new param for the time being
\** Note we may be still few px precision off but I would say the difference is not visible
- I had to expose a number (all?) local vars from the constructor to the file scope in order to use them in `setPosition`
- I tried to reuse one formula for both use cases. If you think the code is very confusing I can split this into two methods, each representing an orientation
- After looking around I'm sure the overlap flagged by Andreas is not possible now as long as legend does not exceed 3 line types. If we want to support more without overlap we need to redesign the hover (perhaps move it to the side like Joy suggested initially)
<img width="245" alt="screen shot 2018-01-09 at 16 25 01" src="https://user-images.githubusercontent.com/10513845/34733375-f8cac9fc-f55f-11e7-9c38-3e3940762f33.png">

*After this point hovers would flip away from each other if drawn closer*
  