### PR TITLE
Prevent hover box causing x-scrollbar to appear

### DIFF
--- a/visualizer/style.css
+++ b/visualizer/style.css
@@ -83,6 +83,8 @@ html, body {
 
 body {
   background: var(--main-bg-color);
+  overflow-x: hidden; /* Hover box padding can overflow. Scrollbar appearing moves recommendation box. */ 
+                      /* If that causes mouse to leave hover area, scrollbar flashes on and off in loop. */
 }
 
 #front-matter {
@@ -94,7 +96,7 @@ body {
 
 #front-matter #alert {
   flex: 1 1 0px;
-  min-width: 0; /* don't consider children for min-width calcultion */
+  min-width: 0; /* don't consider children for min-width calculation */
 }
 
 #front-matter #menu {


### PR DESCRIPTION
Andreas commented that tiny PRs are okay here so long as they do address one issue... so here we go. Sorry Andreas, but strictly speaking this does also fix a typo in a different comment in the same file...

Hover boxes for datapoints on the far right of a graph overflow the body. This creates an x scrollbar on systems not set to hide scrollbars.

Since the x scrollbar pushes the recommendation panel upward, it's possible to cause a flashing infinite loop if the mouse sits over the right-hand edge of a hover area just above the recommendations box, if it is in a position like this on a browser that always show scrollbars.

![image](https://user-images.githubusercontent.com/29628323/35042942-875084d2-fb82-11e7-9a1f-2c1cc32f93ed.png)
