### PR TITLE
Fix ui bug where bottom pointer was shown when it should not

### DIFF
--- a/visualizer/hover-box.js
+++ b/visualizer/hover-box.js
@@ -46,6 +46,7 @@ class HoverBox {
       .attr('height', hoverBoxHeight)
     this.svg.append('path')
       .classed('pointer', true)
+      .classed('above-curve', true)
       .attr('d', `M${this.width / 2 - this.size.pointHeight} ${hoverBoxHeight} ` +
                  `L${this.width / 2} ${this.height} ` +
                  `L${this.width / 2 + this.size.pointHeight} ${hoverBoxHeight} Z`)


### PR DESCRIPTION
Fixes a bug, where when hovering the bottom pointer triangle was shown if the hover box was shown below the graph line.