### PR TITLE
Don't treat Windows SIGINT exit code as error (#97)

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,8 +58,12 @@ class ClinicDoctor {
     })
 
     proc.once('exit', function (code, signal) {
-      // Abort if the process did not exit normally. Windows uncaught SIGINT has exit code 3221225786
-      if (code !== 0 && signal !== 'SIGINT' && !(code === 3221225786 && os.platform() === 'win32')) {
+      // Windows uncaught SIGINT has exit code 3221225786
+      /* istanbul ignore if: windows hack */
+      if (code === 3221225786 && os.platform() === 'win32') signal = 'SIGINT'
+
+      // Abort if the process did not exit normally.
+      if (code !== 0 && signal !== 'SIGINT') {
         if (code !== null) {
           return callback(
             new Error(`process exited with exit code ${code}`),

--- a/index.js
+++ b/index.js
@@ -58,8 +58,8 @@ class ClinicDoctor {
     })
 
     proc.once('exit', function (code, signal) {
-      // the process did not exit normally
-      if (code !== 0 && signal !== 'SIGINT') {
+      // Abort if the process did not exit normally. Windows uncaught SIGINT has exit code 3221225786
+      if (code !== 0 && signal !== 'SIGINT' && !(code === 3221225786 && os.platform() === 'win32')) {
         if (code !== null) {
           return callback(
             new Error(`process exited with exit code ${code}`),

--- a/index.js
+++ b/index.js
@@ -58,7 +58,8 @@ class ClinicDoctor {
     })
 
     proc.once('exit', function (code, signal) {
-      // Windows uncaught SIGINT has exit code 3221225786
+      // Windows exit code STATUS_CONTROL_C_EXIT 0xC000013A returns 3221225786
+      // if not caught. See https://msdn.microsoft.com/en-us/library/cc704588.aspx
       /* istanbul ignore next: windows hack */
       if (code === 3221225786 && os.platform() === 'win32') signal = 'SIGINT'
 

--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ class ClinicDoctor {
 
     proc.once('exit', function (code, signal) {
       // Windows uncaught SIGINT has exit code 3221225786
-      /* istanbul ignore if: windows hack */
+      /* istanbul ignore next: windows hack */
       if (code === 3221225786 && os.platform() === 'win32') signal = 'SIGINT'
 
       // Abort if the process did not exit normally.


### PR DESCRIPTION
If child process doesn't catch errors, Doctor sees raw SIGINT exit code which on Windows is 3221225786; which is treated as an error. See issue https://github.com/nearform/node-clinic-doctor/issues/97 for how to replicate.