### PR TITLE
Big cleanup after the v2 UI

### DIFF
--- a/visualizer/main.js
+++ b/visualizer/main.js
@@ -48,7 +48,7 @@ recommendation.on('close-panel', function () {
   recommendation.draw()
 })
 
-recommendation.on('change-page', function (category) {
+recommendation.on('menu-click', function (category) {
   recommendation.setPage(category)
   recommendation.draw()
 })
@@ -71,6 +71,7 @@ recommendation.on('open-undetected', function () {
 })
 recommendation.on('close-undetected', function () {
   recommendation.closeUndetected()
+  recommendation.setPage(recommendation.defaultCategory)
   recommendation.draw()
 })
 

--- a/visualizer/main.js
+++ b/visualizer/main.js
@@ -42,9 +42,8 @@ recommendation.on('open-panel', function () {
   recommendation.draw()
 })
 recommendation.on('close-panel', function () {
-  recommendation.closePanel()
-  // Remove class before draw so we can rescroll #main element
   document.documentElement.classList.remove('recommendation-open')
+  recommendation.closePanel()
   recommendation.draw()
 })
 
@@ -54,15 +53,15 @@ recommendation.on('menu-click', function (category) {
 })
 
 recommendation.on('open-read-more', function () {
+  document.documentElement.classList.add('recommendation-read-more-open')
   recommendation.openReadMore()
   recommendation.draw()
   recommendation.setPage(recommendation.selectedCategory)
-  document.querySelector('body').classList.add('read-more-open')
 })
 recommendation.on('close-read-more', function () {
+  document.documentElement.classList.remove('recommendation-read-more-open')
   recommendation.closeReadMore()
   recommendation.draw()
-  document.querySelector('body').classList.remove('read-more-open')
 })
 
 recommendation.on('open-undetected', function () {

--- a/visualizer/recommendation.js
+++ b/visualizer/recommendation.js
@@ -14,46 +14,11 @@ class RecomendationWrapper {
 
     this.selected = false
     this.detected = false
-
-    this.articleHeadings = null
-    this.articleSplits = []
-    this.articleMenuItems = []
-
-    this.selectedArticleSection = null
   }
 
   get order () {
     // always make the detected issue appear first
     return this.detected ? 0 : this.content.order
-  }
-
-  // should be done only when scrollingContainer's scrollTop === 0
-  computeArticleSplits () {
-    let startPos
-    this.articleSplits = this.articleHeadings.map((articleHeading, i) => {
-      const top = articleHeading.getBoundingClientRect().top
-      if (i === 0) {
-        startPos = top
-      }
-      return top - startPos
-    })
-
-    // Clear selection else nothing is selected when user returns to previously opened tab
-    this.selectedArticleSection = null
-  }
-
-  updateSelectedArticleSection (scrollingContainer) {
-    const scrollPos = scrollingContainer.node().scrollTop
-    const maxScroll = scrollingContainer.node().scrollHeight - scrollingContainer.node().clientHeight
-    let sectionIndex = scrollPos === maxScroll ? this.articleSplits.length - 1 : d3.bisect(this.articleSplits, scrollPos) - 1
-    sectionIndex = Math.min(this.articleSplits.length - 1, sectionIndex)
-    if (this.selectedArticleSection !== sectionIndex) {
-      if (this.selectedArticleSection !== null) {
-        this.articleMenuItems[this.selectedArticleSection].classList.remove('selected')
-      }
-      this.articleMenuItems[sectionIndex].classList.add('selected')
-      this.selectedArticleSection = sectionIndex
-    }
   }
 
   getSummaryTitle () {
@@ -64,31 +29,9 @@ class RecomendationWrapper {
   }
 
   getSummary () { return this.content.getSummary() }
-
   hasSummary () { return this.content.hasSummary() }
 
-  getReadMore () {
-    const readMore = this.content.getReadMore()
-
-    this.articleHeadings = Array.from(readMore.querySelectorAll('h2'))
-    this.articleHeadings.forEach((articleHeading, i) => {
-      articleHeading.id = `article-section-${i}`
-    })
-
-    this.articleMenuItems = this.articleHeadings.map((articleHeading) => {
-      const link = document.createElement('a')
-      link.href = '#' + articleHeading.id
-      link.textContent = articleHeading.textContent
-      d3.select(link).on('click', () => {
-        window.event.preventDefault()
-        d3.select('#' + articleHeading.id).node().scrollIntoView({ behavior: 'smooth', block: 'start' })
-      })
-      return link
-    })
-
-    return readMore
-  }
-
+  getReadMore () { return this.content.getReadMore() }
   hasReadMore () { return this.content.hasReadMore() }
 }
 
@@ -121,6 +64,7 @@ class Recomendation extends EventEmitter {
       .classed('menu', true)
     this.content = this.details.append('div')
       .classed('content', true)
+      .on('scroll.scroller', () => this._drawSelectedArticleMenu())
     this.summaryTitle = this.content.append('div')
       .classed('summary-title', true)
     this.summary = this.content.append('div')
@@ -198,32 +142,6 @@ class Recomendation extends EventEmitter {
     this.selectedCategory = newCategory
     this.recommendations.get(oldCategory).selected = false
     this.recommendations.get(newCategory).selected = true
-
-    const recommendation = this.recommendations.get(this.selectedCategory)
-    this.container.classed('has-read-more', recommendation.hasReadMore())
-    this.readMoreArticle.html(null)
-    this.articleMenu.html(null)
-    if (recommendation.hasReadMore()) {
-      this.readMoreArticle.node().appendChild(recommendation.getReadMore())
-
-      this.articleMenu.append('h2')
-        .classed('plain', true)
-        .text('Jump to section')
-      for (const menuItem of recommendation.articleMenuItems) {
-        this.articleMenu.node().appendChild(menuItem)
-      }
-
-      if (this.readMoreOpened) {
-        const content = this.content
-        content.node().scrollTo(0, 0)
-        recommendation.computeArticleSplits()
-        recommendation.updateSelectedArticleSection(content)
-        content
-          .on('scroll.scroller', () => {
-            recommendation.updateSelectedArticleSection(content)
-          })
-      }
-    }
   }
 
   draw () {
@@ -241,6 +159,7 @@ class Recomendation extends EventEmitter {
       .classed('open', this.panelOpened)
       .classed('read-more-open', this.readMoreOpened)
       .classed('undetected-opened', this.undetectedOpened)
+      .classed('has-read-more', recommendation.hasReadMore())
       .classed('detected', recommendation.detected)
 
     // set content
@@ -250,9 +169,51 @@ class Recomendation extends EventEmitter {
       this.summary.node().appendChild(recommendation.getSummary())
     }
 
+    this.readMoreArticle.html(null)
+    this.articleMenu.html(null)
+    if (recommendation.hasReadMore()) {
+      this.readMoreArticle.node().appendChild(recommendation.getReadMore())
+
+      this.articleMenu.append('h2')
+        .classed('plain', true)
+        .text('Jump to section')
+
+      this.articleMenu.append('ul')
+        .selectAll('li')
+        .data(this.readMoreArticle.selectAll('h2').nodes())
+        .enter()
+          .append('li')
+          .text((headerElement) => headerElement.textContent)
+          .on('click', function (headerElement) {
+            headerElement.scrollIntoView({ behavior: 'smooth', block: 'start' })
+          })
+
+      this._drawSelectedArticleMenu()
+    }
+
     // set space height such that the fixed element don't have to hide
     // something in the background.
     this.space.style('height', this.details.node().offsetHeight + 'px')
+  }
+
+  _drawSelectedArticleMenu () {
+    const contentScrollTop = this.content.node().scrollTop
+    const contentClientHeight = this.content.node().clientHeight
+
+    function isAboveScrollBottom (headerElement) {
+      const elementBottom = headerElement.offsetTop + headerElement.clientHeight
+      const relativeTopPosition = elementBottom - contentScrollTop
+      return relativeTopPosition <= contentClientHeight
+    }
+
+    const selection = this.articleMenu.select('ul').selectAll('li')
+    const mostRecentHeader = selection.data()
+      .filter(isAboveScrollBottom)
+      .pop()
+
+    selection.classed('selected', function (headerElement) {
+      return headerElement === mostRecentHeader
+    })
   }
 
   openPanel () {

--- a/visualizer/recommendation.js
+++ b/visualizer/recommendation.js
@@ -56,8 +56,17 @@ class RecomendationWrapper {
     }
   }
 
+  getSummaryTitle () {
+    if (this.detected) return `Doctor has found ${this.title}:`
+
+    return `Doctor has not found evidence of ${this.title}.` +
+           ' When such issues are present:'
+  }
+
   getSummary () { return this.content.getSummary() }
+
   hasSummary () { return this.content.hasSummary() }
+
   getReadMore () {
     const readMore = this.content.getReadMore()
 
@@ -79,6 +88,7 @@ class RecomendationWrapper {
 
     return readMore
   }
+
   hasReadMore () { return this.content.hasReadMore() }
 }
 
@@ -234,9 +244,7 @@ class Recomendation extends EventEmitter {
       .classed('detected', recommendation.detected)
 
     // set content
-    this.summaryTitle
-      .text(recommendation.title)
-
+    this.summaryTitle.text(recommendation.getSummaryTitle())
     this.summary.html(null)
     if (recommendation.hasSummary()) {
       this.summary.node().appendChild(recommendation.getSummary())

--- a/visualizer/recommendation.js
+++ b/visualizer/recommendation.js
@@ -88,7 +88,7 @@ class Recomendation extends EventEmitter {
       .enter()
         .append('li')
           .classed('recommendation-tab', true)
-          .on('click', (d) => this.emit('change-page', d.category))
+          .on('click', (d) => this.emit('menu-click', d.category))
     pagesLiEnter.append('span')
       .classed('menu-text', true)
       .attr('data-content', (d) => d.menu)
@@ -232,11 +232,6 @@ class Recomendation extends EventEmitter {
   }
   closeUndetected () {
     this.undetectedOpened = false
-
-    // If user hides undetected tabs while one is selected, switch to default tab
-    if (!this.recommendations.get(this.selectedCategory).detected) {
-      this.emit('change-page', this.defaultCategory)
-    }
   }
 }
 

--- a/visualizer/recommendation.js
+++ b/visualizer/recommendation.js
@@ -99,10 +99,9 @@ class Recomendation extends EventEmitter {
     // Add button to show-hide tabs described undetected issues
     this.pages.append('li')
       .classed('show-hide', true)
-      .append('a')
-        .classed('show-hide-button', true)
+      .on('click', () => this.emit(this.undetectedOpened ? 'close-undetected' : 'open-undetected'))
+      .append('span')
         .classed('menu-text', true)
-        .on('click', () => this.emit(this.undetectedOpened ? 'close-undetected' : 'open-undetected'))
 
     this.menu.append('svg')
       .classed('close', true)
@@ -160,7 +159,6 @@ class Recomendation extends EventEmitter {
       .classed('read-more-open', this.readMoreOpened)
       .classed('undetected-opened', this.undetectedOpened)
       .classed('has-read-more', recommendation.hasReadMore())
-      .classed('detected', recommendation.detected)
 
     // set content
     this.summaryTitle.text(recommendation.getSummaryTitle())
@@ -175,7 +173,6 @@ class Recomendation extends EventEmitter {
       this.readMoreArticle.node().appendChild(recommendation.getReadMore())
 
       this.articleMenu.append('h2')
-        .classed('plain', true)
         .text('Jump to section')
 
       this.articleMenu.append('ul')

--- a/visualizer/style.css
+++ b/visualizer/style.css
@@ -384,6 +384,10 @@ svg#toggle-theme {
 }
 
 #recommendation .details .content {
+   /* make this the offsetParent, such that `.article h2` has a `offsetTop`
+      that is relative to `.content` */
+  position: relative;
+
   flex: 0 1 auto;
   /* in firefox `flex: 0 1 auto` takes up the content space instead of the
      available space. Set min-height to indicate that the auto height can
@@ -514,7 +518,12 @@ svg#toggle-theme {
  align-self: flex-start;
 }
 
-#recommendation .content .read-more h2:not(.plain), #recommendation.open.read-more-open .article-menu a {
+#recommendation.open.read-more-open .article-menu ul {
+  margin: 0;
+  padding: 0;
+}
+
+#recommendation .content .read-more h2:not(.plain), #recommendation.open.read-more-open .article-menu li {
   background: var(--recommend-title-bg-color);
   font-size: 12pt;
   padding: 12px;
@@ -525,10 +534,11 @@ svg#toggle-theme {
   color: var(--recommend-text-color);
 }
 
-#recommendation.open.read-more-open .article-menu a {
+#recommendation.open.read-more-open .article-menu li {
  display: block;
  margin-bottom: 6px;
  background-color: var(--article-menu-color);
+ cursor: pointer;
 }
 
 #recommendation .content .read-more h2.plain {
@@ -575,7 +585,7 @@ svg#toggle-theme {
   float: left;
 }
 
-#recommendation .menu ul li.selected, #recommendation.open.read-more-open .article-menu a.selected {
+#recommendation .menu ul li.selected, #recommendation.open.read-more-open .article-menu li.selected {
   border-bottom: 4px solid var(--recommend-menu-selected-color);
   font-weight: bold;
 }

--- a/visualizer/style.css
+++ b/visualizer/style.css
@@ -85,7 +85,9 @@ body {
                       /* If that causes mouse to leave hover area, scrollbar flashes on and off in loop. */
 }
 
-.recommendation-open body.read-more-open {
+/* TODO(16-02-2018): Remove once overscroll-behavior-y gets better browser
+  support. Currently only supported by Chrome and the next version of Firefox. */
+html.recommendation-open.recommendation-read-more-open {
   overflow-y: hidden;
 }
 

--- a/visualizer/style.css
+++ b/visualizer/style.css
@@ -578,13 +578,13 @@ svg#toggle-theme {
   cursor: pointer;
 }
 
-#recommendation .menu ul li.show-hide .show-hide-button {
+#recommendation .menu ul li.show-hide {
   color: var(--recommend-link-color);
 }
-#recommendation .menu ul li.show-hide .show-hide-button::before {
+#recommendation .menu ul li.show-hide .menu-text::before {
   content: 'Browse undetected issues ❮';
 }
-#recommendation.undetected-opened .menu ul li.show-hide .show-hide-button::before {
+#recommendation.undetected-opened .menu ul li.show-hide .menu-text::before {
   content: 'Hide ❯';
 }
 

--- a/visualizer/style.css
+++ b/visualizer/style.css
@@ -41,9 +41,6 @@ html {
   --recommend-bg-color: rgba(55, 61, 79, 0.99);
 
   --article-menu-color: rgb(27, 30, 39);
-
-  --special-scrollbar-bg: rgba(255, 255, 255, .5);
-  --special-scrollbar-shadow: rgba(0, 0, 0, .5);
 }
 
 html.light-theme {
@@ -67,9 +64,6 @@ html.light-theme {
   --recommend-link-color: rgb(31, 91, 162);
   --recommend-close-color: rgb(63, 125, 198);
   --recommend-bg-color: rgb(209, 211, 218);
-
-  --special-scrollbar-bg: rgba(0, 0, 0, .5);
-  --special-scrollbar-shadow: rgba(255, 255, 255, .5);
 
   --article-menu-color: rgb(227, 227, 227);
 }
@@ -339,14 +333,11 @@ svg#toggle-theme {
   justify-content: flex-start;
   align-items: stretch;
 }
+#recommendation.open .details {
+  display: flex;
+}
 #recommendation.open.read-more-open .details {
   min-height: calc(100vh - 65px - 65px); /* 100% - #banner[height] .bar[height] */
-}
-
-#recommendation.open.read-more-open .details .content {
-  display: block;
-  padding-right: 7px;
-  overflow-y: scroll;
 }
 
 /* change the scroll area to be the entire content if the screen-size is
@@ -355,11 +346,6 @@ svg#toggle-theme {
   #recommendation .details {
     min-height: unset;
   }
-}
-
-
-#recommendation.open .details {
-  display: flex;
 }
 
 #recommendation .details .menu {
@@ -394,35 +380,34 @@ svg#toggle-theme {
      be less than the content. */
   min-height: 0px;
 
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-end;
-  align-items: stretch;
-}
-
-#recommendation .details .content .summary-title {
-  flex: 0 0 auto;
-}
-
-#recommendation .details .content .summary {
-  flex: 0 0 auto;
-}
-
-#recommendation .details .content .read-more-button {
-  flex: 0 0 auto;
+  overflow-y: scroll;
+  overscroll-behavior-y: contain; /* prevent scolling the main window */
 }
 
 #recommendation .details .content .read-more {
   display: none;
-  flex: 0 1 auto;
-  min-height: 0px; /* make auto be the available space instead of content space */
-  padding-right: 7px;
-  flex-direction: row;
-  justify-content: center;
 }
 #recommendation.read-more-open .details .content .read-more {
   display: flex;
 }
+
+#recommendation .content .read-more .article {
+  max-width: 550px;
+  flex: 1 1 auto;
+}
+
+#recommendation .content .read-more .article-menu {
+  flex: 0 0 240px;
+  align-self: flex-start;
+  position: sticky;
+  top: 0;
+}
+@media (max-width: 670px) {
+  #recommendation .content .read-more .article-menu {
+    display: none;
+  }
+}
+
 
 #recommendation .bar {
   flex: 0 0 65px;
@@ -442,7 +427,6 @@ svg#toggle-theme {
   padding: 18px 28px;
   font-size: 12pt;
   line-height: 1.5em;
-  overscroll-behavior-y: contain; /* prevent scolling the main window */
 }
 
 #recommendation .content a {
@@ -450,22 +434,11 @@ svg#toggle-theme {
   text-decoration: none;
 }
 
-#recommendation ::-webkit-scrollbar {
-  -webkit-appearance: none;
-  width: 7px;
-}
-#recommendation ::-webkit-scrollbar-thumb {
-  border-radius: 4px;
-  background-color: var(--special-scrollbar-bg);
-  -webkit-box-shadow: 0 0 1px var(--special-shadow-bg);
-}
-
 #recommendation .content .summary-title {
-  display: block;
   padding-top: 16px;
 }
 
-#recommendation .content .read-more-button, #recommendation .menu .show-hide-button {
+#recommendation .content .read-more-button {
   display: none;
   color: var(--recommend-link-color);
   cursor: pointer;
@@ -473,7 +446,9 @@ svg#toggle-theme {
 #recommendation .content .read-more-button::before {
   content: 'Read more';
 }
-
+#recommendation.has-read-more .content .read-more-button {
+  display: block;
+}
 #recommendation.read-more-open .content .read-more-button {
   margin-bottom: 10px;
 }
@@ -481,73 +456,43 @@ svg#toggle-theme {
   content: 'Read less';
 }
 
-#recommendation .menu ul li .show-hide-button {
-  display: block;
-  align-self: unset;
-}
-#recommendation .menu ul li .menu-text.show-hide-button::before {
-  content: 'Browse undetected issues ❮';
-}
-#recommendation.undetected-opened .menu ul li .menu-text.show-hide-button::before {
-  content: 'Hide ❯';
-}
-
-
-#recommendation.has-read-more .content .read-more-button {
-  display: block;
-}
-
-#recommendation.has-read-more .content .read-more p {
-  line-height: 24px;
-  margin-top: 18px;
-  margin-bottom: 18px;
-  text-align: left;
-}
-
-#recommendation.open.read-more-open .article {
- display: inline-block;
- max-width: 550px;
- margin-bottom: 128px;
-}
-
-#recommendation.open.read-more-open .article-menu {
- margin-right: 40px;
- max-width: 550px;
- position: sticky;
- top: 0;
- align-self: flex-start;
-}
-
-#recommendation.open.read-more-open .article-menu ul {
-  margin: 0;
-  padding: 0;
-}
-
-#recommendation .content .read-more h2:not(.plain), #recommendation.open.read-more-open .article-menu li {
+#recommendation .content .article h2 {
   background: var(--recommend-title-bg-color);
   font-size: 12pt;
   padding: 12px;
-  break-after: avoid;
-  break-before: auto;
   margin: 0; /* let p and ul tags dominate margin collapse */
   font-weight: bold;
   color: var(--recommend-text-color);
 }
 
-#recommendation.open.read-more-open .article-menu li {
- display: block;
- margin-bottom: 6px;
- background-color: var(--article-menu-color);
- cursor: pointer;
+#recommendation .content .article p {
+  line-height: 24px;
+  margin-top: 18px;
+  margin-bottom: 18px;
 }
 
-#recommendation .content .read-more h2.plain {
+#recommendation .content .article-menu {
+  margin-right: 40px;
+}
+
+#recommendation .content .article-menu h2 {
   font-size: 12pt;
   padding-left: 12px;
 }
 
-#recommendation .content .read-more li {
-  orphans: 4;
+#recommendation .content .article-menu ul {
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+}
+
+#recommendation .content .article-menu li {
+  margin-bottom: 6px;
+  padding: 12px;
+  background-color: var(--article-menu-color);
+  font-weight: bold;
+  color: var(--recommend-text-color);
+  cursor: pointer;
 }
 
 #recommendation .menu {
@@ -631,6 +576,16 @@ svg#toggle-theme {
 #recommendation .menu svg.close {
   fill: var(--recommend-close-color);
   cursor: pointer;
+}
+
+#recommendation .menu ul li.show-hide .show-hide-button {
+  color: var(--recommend-link-color);
+}
+#recommendation .menu ul li.show-hide .show-hide-button::before {
+  content: 'Browse undetected issues ❮';
+}
+#recommendation.undetected-opened .menu ul li.show-hide .show-hide-button::before {
+  content: 'Hide ❯';
 }
 
 #recommendation .bar {
@@ -749,16 +704,6 @@ svg#toggle-theme {
 
   #graph .sub-graph .header .legend .legend-item .short-legend {
     display: unset;
-  }
-
-  #recommendation.open.read-more-open .article-menu {
-   margin-right: 0;
-   position: static;
-   align-self: unset;
-  }
-
-  #recommendation.read-more-open .details .content .read-more {
-   display: block; /* Allows .article-menu to move above content */
   }
 }
 

--- a/visualizer/style.css
+++ b/visualizer/style.css
@@ -87,7 +87,7 @@ html, body {
 
 body {
   background: var(--main-bg-color);
-  overflow-x: hidden; /* Hover box padding can overflow. Scrollbar appearing moves recommendation box. */ 
+  overflow-x: hidden; /* Hover box padding can overflow. Scrollbar appearing moves recommendation box. */
                       /* If that causes mouse to leave hover area, scrollbar flashes on and off in loop. */
 }
 
@@ -236,10 +236,6 @@ html.light-theme #front-matter, html.light-theme #graph, html.light-theme #recom
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow: hidden;
-}
-
-#alert .summary .title::before {
-  content: 'Detected ';
 }
 
 #alert .summary .toggle {
@@ -464,20 +460,6 @@ svg#toggle-theme {
   display: block;
   padding-top: 16px;
 }
-#recommendation .content .summary-title::before {
-  content: 'Doctor has not found evidence of ';
-}
-
-#recommendation .content .summary-title::after {
-  content: '. When such issues are present:'
-}
-#recommendation.detected .content .summary-title::before {
-  content: 'Doctor has found ';
-}
-#recommendation.detected .content .summary-title::after {
-  content: ':'
-}
-
 
 #recommendation .content .read-more-button, #recommendation .menu .show-hide-button {
   display: none;
@@ -582,7 +564,7 @@ svg#toggle-theme {
   display: none;
 }
 
-#recommendation .menu ul li, 
+#recommendation .menu ul li,
 #recommendation .menu ul li.detected,
 #recommendation .menu ul li.selected,
 #recommendation.undetected-opened .menu ul li.has-read-more {


### PR DESCRIPTION
I had to do something for the flights and airports where I didn't have any internet connect ;)

I would have liked for @kamil-mech or @AlanSl to do this. Unfortunately, that couldn't be prioritized. Thus I think it is important that you take your time to at least digest these changes:

**Actual fixes and changes:**

* `on('scroll.scroller')` is only applied once, thus we no longer leak an event listener
* small screens now overflow correctly:

![skaermbillede 2018-02-16 kl 12 40 09](https://user-images.githubusercontent.com/505333/36306100-8ee7fcc4-1316-11e8-9efb-de77914fe092.png)

* the article navigation no longer shows on small screens:

![skaermbillede 2018-02-16 kl 12 41 15](https://user-images.githubusercontent.com/505333/36306143-c59e5d76-1316-11e8-9726-ea9b6096ea0c.png)
 
* The right-padding is now the same for both summary and read-more.

* fixed bugs in article navigation scrolling logic

![skaermbillede 2018-02-16 kl 13 20 41](https://user-images.githubusercontent.com/505333/36307385-3e633420-131c-11e8-9f0e-44885c7f8d9b.png)

* All the read-more is now floating to the left. Feel free to change this, I just prefer it to be consistent with the summary.

**Refactors:**

* Removed `getPseudoContent` logic.
* `closeUndetected` that is an action no longer emits an event (events should only come from users).
* Moved the navigation menu builder out of the state-management and into `draw`.
* `draw` is now the only function that draws.
* Removed a lot of redundant css
* Changed `display-inline` (hack?) to `flexbox` for the article-navigation and read-more content.
* Removed unused `CSS` classes.
* Moved `body.read-more-open` to `<html>`.

**What I didn't fix**:
* The suggested refactor for the recommendation menu (https://github.com/nearform/node-clinic-doctor/pull/85#discussion_r163216426) 

PS: yes, this should have been done in separate PRs. However, I will be more or less away from tomorrow.