### PR TITLE
Support http: true and emit listening

### DIFF
--- a/detect-port.js
+++ b/detect-port.js
@@ -1,0 +1,9 @@
+const onlisten = require('on-net-listen')
+const fs = require('fs')
+
+onlisten(function (addr) {
+  this.destroy()
+  const port = Buffer.from(addr.port + '')
+  fs.writeSync(3, port, 0, port.length)
+  fs.closeSync(3)
+})

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "debug": "^3.1.0",
     "distributions": "^1.1.0",
     "endpoint": "^0.4.5",
+    "on-net-listen": "^1.0.0",
     "protocol-buffers": "^3.2.1",
     "pump": "^1.0.3",
     "pumpify": "^1.3.6",

--- a/test/cmd-collect-http.test.js
+++ b/test/cmd-collect-http.test.js
@@ -1,0 +1,31 @@
+'use strict'
+
+const test = require('tap').test
+const http = require('http')
+const CollectAndRead = require('./collect-and-read.js')
+
+test('cmd - collect - detect server port', function (t) {
+  const cmd = new CollectAndRead({http: true}, '-e', `
+    const http = require('http')
+    http.createServer(onrequest).listen(0)
+
+    function onrequest (req, res) {
+      this.close()
+      res.end('from server')
+    }
+  `)
+
+  cmd.tool.on('listening', function (port) {
+    t.ok(typeof port === 'number')
+    t.ok(port > 0)
+
+    http.get(`http://127.0.0.1:${port}`, function (res) {
+      const buf = []
+      res.on('data', data => buf.push(data))
+      res.on('end', function () {
+        t.deepEquals(Buffer.concat(buf), Buffer.from('from server'))
+        t.end()
+      })
+    })
+  })
+})

--- a/test/collect-and-read.js
+++ b/test/collect-and-read.js
@@ -14,7 +14,7 @@ class CollectAndRead extends events.EventEmitter {
   constructor (options, ...args) {
     super()
     const self = this
-    const tool = new ClinicDoctor(options)
+    const tool = this.tool = new ClinicDoctor(options)
 
     tool.collect([process.execPath, ...args], function (err, dirname) {
       self.files = getLoggingPaths({ path: dirname })


### PR DESCRIPTION
Adds a new option, `http: true` to the constructor that will make it emit `listening` when the first tcp/http server starts listening in the spawned script.

The `listening` event has the port, which allows for a module consumer to automate http benchmarking against the script.