### PR TITLE
Emit process when listening

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,11 +25,11 @@ class ClinicDoctor extends events.EventEmitter {
     // define default parameters
     const {
       sampleInterval = 10,
-      http = false
+      detectPort = false
     } = settings
 
     this.sampleInterval = sampleInterval
-    this.http = http
+    this.detectPort = detectPort
   }
 
   collect (args, callback) {
@@ -43,7 +43,7 @@ class ClinicDoctor extends events.EventEmitter {
 
     const stdio = ['inherit', 'inherit', 'inherit']
 
-    if (this.http) {
+    if (this.detectPort) {
       const detectPortPath = path.resolve(__dirname, 'detect-port.js')
       logArgs.push('-r', detectPortPath)
       stdio.push('pipe')
@@ -59,10 +59,8 @@ class ClinicDoctor extends events.EventEmitter {
       })
     })
 
-    if (this.http) {
-      proc.stdio[3].once('data', data => {
-        this.emit('listening', Number(data), proc)
-      })
+    if (this.detectPort) {
+      proc.stdio[3].once('data', data => this.emit('port', Number(data), proc))
     }
 
     // get logging directory structure

--- a/index.js
+++ b/index.js
@@ -60,7 +60,9 @@ class ClinicDoctor extends events.EventEmitter {
     })
 
     if (this.http) {
-      proc.stdio[3].once('data', data => this.emit('listening', Number(data)))
+      proc.stdio[3].once('data', data => {
+        this.emit('listening', Number(data), proc)
+      })
     }
 
     // get logging directory structure

--- a/test/cmd-collect-detect-port.test.js
+++ b/test/cmd-collect-detect-port.test.js
@@ -5,7 +5,7 @@ const http = require('http')
 const CollectAndRead = require('./collect-and-read.js')
 
 test('cmd - collect - detect server port', function (t) {
-  const cmd = new CollectAndRead({http: true}, '-e', `
+  const cmd = new CollectAndRead({detectPort: true}, '-e', `
     const http = require('http')
     http.createServer(onrequest).listen(0)
 
@@ -15,7 +15,7 @@ test('cmd - collect - detect server port', function (t) {
     }
   `)
 
-  cmd.tool.on('listening', function (port) {
+  cmd.tool.on('port', function (port) {
     t.ok(typeof port === 'number')
     t.ok(port > 0)
 


### PR DESCRIPTION
Changed my previous PR a bit.

The event is called `port` now and the flag to enable it is `detectPort`.
The spawned process is also emitted with the event as we need a reference to it to kill it cross platform