### PR TITLE
Link Doctor logo to Doctor on Github

### DIFF
--- a/index.js
+++ b/index.js
@@ -205,8 +205,12 @@ class ClinicDoctor extends events.EventEmitter {
       <style>${styleFile}</style>
 
       <div id="banner">
-        ${logoFile}
-        <a href="https://nearform.com" title="nearForm" target="_blank">${nearFormLogoFile}</a>
+        <a href="https://github.com/nearform/node-clinic-doctor" title="Clinic Doctor on GitHub" target="_blank">
+          ${logoFile}
+        </a>
+        <a href="https://nearform.com" title="nearForm" target="_blank">
+          ${nearFormLogoFile}
+        </a>
       </div>
       <div id="front-matter">
         <div id="alert"></div>

--- a/visualizer/style.css
+++ b/visualizer/style.css
@@ -185,7 +185,7 @@ html.light-theme #front-matter, html.light-theme #graph, html.light-theme #recom
   margin-left: 28px;
 }
 
-#banner svg:last-child {
+#banner a:last-child svg {
   position: absolute;
   height: 40px;
   right: 28px;


### PR DESCRIPTION
Also discussed yesterday briefly. Currently the nearForm logos on Clinic products link to the nearForm site, but their own logos don't link anywhere.

We're talking about having a standalone Clinic site, but that's quite a way off. Since the target audience is devs, in the meantime it seems logical to link the Doctor logo to the Doctor GitHub page.