### PR TITLE
Fix duplicated link in references section

### DIFF
--- a/recommendations/event-loop-readmore.md
+++ b/recommendations/event-loop-readmore.md
@@ -46,7 +46,7 @@ the bottleneck may be distributed which would take rather more detective work.
 
 - Load Shedding
   - Express, Koa, Restify, `http`: [overload-protection](https://www.npmjs.com/package/overload-protection)
-  - Hapi: [Server load sampleInterval option](https://hapijs.com/api#new-serveroptions) & [Server connections load maxEventLoopDelay](https://hapijs.com/api#new-serveroptions)
+  - Hapi: [Server load sampleInterval option](https://hapijs.com/api#new-serveroptions) & [Server connections load maxEventLoopDelay](https://hapijs.com/api#-serveroptionsload)
   - Fastify: [under-pressure](https://www.npmjs.com/package/under-pressure)
   - General: [loopbench](https://www.npmjs.com/package/loopbench)
 - [Concurrency model and Event Loop


### PR DESCRIPTION
For this very old issue: https://github.com/nearform/node-clinic-doctor/issues/29

One of the references has two links pointing to the same URL. All the other links look fine. I've fixed the second link to point to the section that discusses `maxEventLoopDelay`