### PR TITLE
add cb to port event

### DIFF
--- a/detect-port.js
+++ b/detect-port.js
@@ -1,12 +1,19 @@
 const onlisten = require('on-net-listen')
 const fs = require('fs')
+const net = require('net')
 
 onlisten(function (addr) {
   this.destroy()
   const port = Buffer.from(addr.port + '')
-  const buf = Buffer.alloc(1)
   fs.writeSync(3, port, 0, port.length)
-  fs.read(3, buf, 0, 1, null, function () {
+  signal(3, function () {
     process.exit(0)
   })
 })
+
+function signal (fd, cb) {
+  const s = new net.Socket({fd, readable: true, writable: false})
+  s.unref()
+  s.on('error', () => {})
+  s.on('close', cb)
+}

--- a/detect-port.js
+++ b/detect-port.js
@@ -4,6 +4,9 @@ const fs = require('fs')
 onlisten(function (addr) {
   this.destroy()
   const port = Buffer.from(addr.port + '')
+  const buf = Buffer.alloc(1)
   fs.writeSync(3, port, 0, port.length)
-  fs.closeSync(3)
+  fs.read(3, buf, 0, 1, null, function () {
+    process.exit(0)
+  })
 })

--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ class ClinicDoctor extends events.EventEmitter {
     })
 
     if (this.detectPort) {
-      proc.stdio[3].once('data', data => this.emit('port', Number(data), proc))
+      proc.stdio[3].once('data', data => this.emit('port', Number(data), proc, () => proc.stdio[3].destroy()))
     }
 
     // get logging directory structure

--- a/test/cmd-collect-detect-port.test.js
+++ b/test/cmd-collect-detect-port.test.js
@@ -29,3 +29,29 @@ test('cmd - collect - detect server port', function (t) {
     })
   })
 })
+
+test('cmd - collect - detect server port and cb', function (t) {
+  const cmd = new CollectAndRead({detectPort: true}, '-e', `
+    const http = require('http')
+    http.createServer(onrequest).listen(0)
+
+    function onrequest (req, res) {
+      res.end('from server')
+    }
+  `)
+
+  cmd.tool.on('port', function (port, proc, cb) {
+    t.ok(typeof port === 'number')
+    t.ok(port > 0)
+
+    http.get(`http://127.0.0.1:${port}`, function (res) {
+      const buf = []
+      res.on('data', data => buf.push(data))
+      res.on('end', function () {
+        t.deepEquals(Buffer.concat(buf), Buffer.from('from server'))
+        t.end()
+        cb()
+      })
+    })
+  })
+})


### PR DESCRIPTION
Adds a callback to the `tool` event that allows you to signal to the subprocess that it should kill itself gracefully

```js
tool.on('port', port, proc, cb) {
  ... do stuff ...
  cb() // signals to the process that it should kill itself
})
```