### PR TITLE
Fix MS Edge iterable errors

### DIFF
--- a/visualizer/icons.js
+++ b/visualizer/icons.js
@@ -25,7 +25,10 @@ class Icon {
   }
 
   insert (svgNode) {
-    for (const attr of this.svgTemplateNode.attributes) {
+    // DOM node attributes list is not iterable in MS Edge, but can be turned into an array
+    const attributes = this.svgTemplateNode.attributes
+    const iterableAttributes = typeof attributes[Symbol.iterator] === 'function' ? attributes : Array.from(attributes)
+    for (const attr of iterableAttributes) {
       svgNode.setAttribute(attr.name, attr.value)
     }
     svgNode.appendChild(this.svgTemplateContent.cloneNode(true))
@@ -74,9 +77,8 @@ class Icons {
   insertIcon (name) {
     const icon = this._icons.get(name)
     return function (selection) {
-      for (const node of selection.nodes()) {
-        icon.insert(node)
-      }
+      // d3's selection.nodes() is an array, but for ... of breaks MS Edge, can't see the array's [Symbol.iterator]
+      selection.nodes().forEach(node => icon.insert(node))
     }
   }
 }


### PR DESCRIPTION
_(MS Edge isn't currently one of the officially supported browsers, but that might change soon - and working is better than completely crashing)_

Previously, Doctor profiles in MS Edge crash and burn with errors claiming various things aren't iterable.

This fixes two such errors and gets profiles working pretty much fine in MS Edge.

- MS Edge doesn't treat DOM node attribute lists as iterable, but can run Array.from around them. Array.from is pretty slow so this PR only uses it if the list isn't iterable.
- Bizarrely, Edge treats the array of nodes returned by D3's selection.nodes() as not iterable - even though it's just an array, not something special like a `NodeList` (which it seems Edge _does_ now treat as iterable...). This doesn't make much sense - but the array method `forEach` works fine here, so this uses that. 

Before (https://upload.clinicjs.org/public/807095e89cf6202752c7ccc35c756bc345f0aabe599f683cfc77b4c946c0e74a/2615.clinic-doctor.html): 

![image](https://user-images.githubusercontent.com/29628323/43311557-b63d7b88-9182-11e8-93c2-26961cc576fb.png)

After (https://upload.clinicjs.org/public/3fcd36d2a0ea9cda50b5d30c639de812d6c802d629be3ac340f4124754696c48/2836.clinic-doctor.html): 

![image](https://user-images.githubusercontent.com/29628323/43311589-cbe927ca-9182-11e8-8009-2197635be7e0.png)

(The security error is a separate issue which appears on profiles uploaded to the server only. It's normally an error caused by cross domain issues, and it doesn't make much sense here because these profiles should be completely self-contained. Added it to https://github.com/nearform/node-clinic-doctor/issues/138 )