### PR TITLE
use @nearform/trace-events-parser

### DIFF
--- a/format/trace-event-decoder.js
+++ b/format/trace-event-decoder.js
@@ -2,7 +2,7 @@
 
 const stream = require('../lib/destroyable-stream')
 const endpoint = require('endpoint')
-const JSONStream = require('JSONStream')
+const parser = require('@nearform/trace-events-parser')
 
 // This list is from: https://github.com/catapult-project/catapult/blob/master
 //   /tracing/tracing/metrics/v8/gc_metric_test.html#L50L57
@@ -31,9 +31,9 @@ class TraceEventDecoder extends stream.Transform {
     this.systemInfoReader = systemInfoReader
     this.clockOffset = null
 
-    // JSONStream is synchronous so there is no need to think about
+    // trace-events-parser is synchronous so there is no need to think about
     // backpresure
-    this.parser = JSONStream.parse('traceEvents.*')
+    this.parser = parser()
     this.parser.on('data', (data) => this._process(data))
     this.systemInfoReader.on('error', (err) => this.destroy(err))
   }

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "lint": "standard --fix | snazzy"
   },
   "dependencies": {
+    "@nearform/trace-events-parser": "^1.0.0",
     "@tensorflow/tfjs-core": "^0.12.11",
-    "JSONStream": "^1.3.2",
     "async": "^2.6.0",
     "brfs": "^2.0.0",
     "browserify": "^16.1.1",

--- a/test/format-trace-event.test.js
+++ b/test/format-trace-event.test.js
@@ -7,7 +7,8 @@ const SystemInfoDecoder = require('../format/system-info-decoder.js')
 const TraceEventDecoder = require('../format/trace-event-decoder.js')
 
 function traceEvent (data) {
-  return Object.assign({ pid: 10, tid: 1, ph: 'X', cat: 'v8', args: {} }, data)
+  // we put args: {}, at the end as the fast parser expects that
+  return Object.assign({ pid: 10, tid: 1, ph: 'X', cat: 'v8' }, data, { args: {} })
 }
 
 test('Format - trace event - combine', function (t) {


### PR DESCRIPTION
Should give us a good boost in parsing speedup similar to the one we got in bprof (2-3x)