### PR TITLE
Throw error if a cluster subprocess is forked

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,6 +39,7 @@ class ClinicDoctor extends events.EventEmitter {
   collect (args, callback) {
     // run program, but inject the sampler
     const logArgs = [
+      '-r', 'no-cluster.js',
       '-r', 'sampler.js',
       '--trace-events-enabled', '--trace-event-categories', 'v8'
     ]

--- a/injects/no-cluster.js
+++ b/injects/no-cluster.js
@@ -1,5 +1,5 @@
 const cluster = require('cluster')
 
 cluster.on('fork', () => {
-  throw new Error('bubbleprof does not support clustering.')
+  throw new Error('clinic doctor does not support clustering.')
 })

--- a/injects/no-cluster.js
+++ b/injects/no-cluster.js
@@ -1,0 +1,5 @@
+const cluster = require('cluster')
+
+cluster.on('fork', () => {
+  throw new Error('bubbleprof does not support clustering.')
+})

--- a/test/cmd-no-cluster.script.js
+++ b/test/cmd-no-cluster.script.js
@@ -1,0 +1,11 @@
+const rimraf = require('rimraf')
+const ClinicDoctor = require('../index.js')
+
+const doctor = new ClinicDoctor({})
+doctor.collect([
+  process.execPath,
+  '-e', 'var c = require("cluster"); c.isMaster && c.fork()'
+], (err, result) => {
+  rimraf.sync(result)
+  if (err) throw err
+})

--- a/test/cmd-no-cluster.test.js
+++ b/test/cmd-no-cluster.test.js
@@ -1,0 +1,26 @@
+'use strict'
+
+const test = require('tap').test
+const { spawn } = require('child_process')
+const endpoint = require('endpoint')
+const rimraf = require('rimraf')
+const ClinicDoctor = require('../index.js')
+
+test('collect command stops when cluster is used', function (t) {
+  t.plan(3)
+
+  const doctor = new ClinicDoctor({})
+  doctor.collect([process.execPath, '-e', 'require("cluster")'], (err, result) => {
+    t.ifError(err, 'should not crash when cluster is required but not used')
+    rimraf.sync(result)
+  })
+
+  const proc = spawn(process.execPath, [
+    require.resolve('./cmd-no-cluster.script.js')
+  ], { stdio: 'pipe' })
+
+  proc.stderr.pipe(endpoint((err, buf) => {
+    t.ifError(err)
+    t.ok(buf.toString('utf8').includes('does not support clustering'), 'should crash once cluster is used')
+  }))
+})


### PR DESCRIPTION
See https://github.com/davidmarkclements/0x/pull/155

The test that does `cluster.fork()` generates output so I moved that into a subprocess. The test that just does `require('cluster')` doesn't generate any output so I left it inline.