### PR TITLE
Prevent memory exhaustion

### DIFF
--- a/injects/sampler.js
+++ b/injects/sampler.js
@@ -23,7 +23,7 @@ const processStat = new ProcessStat(parseInt(
   process.env.NODE_CLINIC_DOCTOR_SAMPLE_INTERVAL, 10
 ))
 
-// keep sample time unrefed such it doesn't interfer too much
+// keep sample time unrefed such it doesn't interfere too much
 let timer = null
 function scheduleSample () {
   timer = setTimeout(saveSample, processStat.sampleInterval)
@@ -38,7 +38,7 @@ function saveSample () {
   scheduleSample()
 }
 
-// start sampler on next tick, to avoid measureing the startup time
+// start sampler on next tick, to avoid measuring the startup time
 process.nextTick(function () {
   processStat.refresh()
   scheduleSample()

--- a/test/cmd-visualize.test.js
+++ b/test/cmd-visualize.test.js
@@ -13,7 +13,7 @@ test('cmd - test visualization - data exists', function (t) {
   function cleanup (err, dirname) {
     t.ifError(err)
 
-    t.match(dirname, /^foo\/[0-9]+\.clinic-doctor$/)
+    t.match(dirname, /^foo(\/|\\)[0-9]+\.clinic-doctor$/)
 
     async.parallel([
       (done) => rimraf(dirname, done),

--- a/test/cmd-visualize.test.js
+++ b/test/cmd-visualize.test.js
@@ -1,7 +1,8 @@
 'use strict'
 
 const fs = require('fs')
-const test = require('tap').test
+const v8 = require('v8')
+const { test } = require('tap')
 const async = require('async')
 const rimraf = require('rimraf')
 const ClinicDoctor = require('../index.js')
@@ -12,6 +13,8 @@ test('cmd - test visualization - data exists', function (t) {
   function cleanup (err, dirname) {
     t.ifError(err)
 
+    t.match(dirname, /^foo\/[0-9]+\.clinic-doctor$/)
+
     async.parallel([
       (done) => rimraf(dirname, done),
       (done) => fs.unlink(dirname + '.html', done)
@@ -20,6 +23,63 @@ test('cmd - test visualization - data exists', function (t) {
       t.end()
     })
   }
+
+  tool.collect(
+    [process.execPath, '-e', 'setTimeout(() => {}, 200)'],
+    function (err, dirname) {
+      if (err) return cleanup(err, dirname)
+
+      tool.visualize(dirname, dirname + '.html', function (err) {
+        if (err) return cleanup(err, dirname)
+
+        fs.readFile(dirname + '.html', function (err, content) {
+          if (err) return cleanup(err, dirname)
+
+          t.ok(content.length > 1024)
+          cleanup(null, dirname)
+        })
+      })
+    }
+  )
+})
+
+test('cmd - test visualization - memory exhausted', function (t) {
+  const tmp = process.memoryUsage
+  const HEAP_MAX = v8.getHeapStatistics().heap_size_limit
+
+  // Mock the used function to pretend the memory is exhausted.
+  process.memoryUsage = () => {
+    return {
+      rss: 0,
+      heapTotal: HEAP_MAX,
+      heapUsed: 0,
+      external: 0
+    }
+  }
+
+  const tool = new ClinicDoctor()
+
+  function cleanup (err, dirname) {
+    process.memoryUsage = tmp
+    t.ifError(err)
+
+    t.match(dirname, /^[0-9]+\.clinic-doctor$/)
+
+    async.parallel([
+      (done) => rimraf(dirname, done),
+      (done) => fs.unlink(dirname + '.html', done)
+    ], function (err) {
+      t.ifError(err)
+      t.end()
+    })
+  }
+
+  tool.on('warning', function (warning) {
+    t.equal(warning, 'Truncating input data due to memory constrains')
+  })
+  tool.on('truncate', function (undef) {
+    t.equal(undef, undefined)
+  })
 
   tool.collect(
     [process.execPath, '-e', 'setTimeout(() => {}, 200)'],


### PR DESCRIPTION
This cuts the data streams when the heap runs low on memory. In that
case a warning will be emitted.

Fixes: #147

This is still WIP as I have to find a good test case to validate this against (that's why the CI fails as well). I am not sure if emitting the warning as is will be enough either. @mcollina @AlanSl would you be so kind and have a look?