### PR TITLE
Update hidden-markov-model-tf to version 1.1.1 (fix for Node 8)

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "debug": "^4.0.0",
     "distributions": "^1.1.0",
     "endpoint": "^0.4.5",
-    "hidden-markov-model-tf": "^1.0.1",
+    "hidden-markov-model-tf": "^1.1.1",
     "minify-stream": "^1.2.0",
     "mkdirp": "^0.5.1",
     "node-trace-log-join": "^1.0.0",


### PR DESCRIPTION
Keep Greenkeeper happy https://github.com/nearform/node-clinic-doctor/issues/177 

1.1.1 is a patch fixing the dep in Node 8.