### PR TITLE
adding the 'visualize' debug tool to improve the dev exp.

### DIFF
--- a/debug/visualize-all.js
+++ b/debug/visualize-all.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+var v = require('./visualize-mod.js')
+v.visualize({ debug: true })

--- a/debug/visualize-mod.js
+++ b/debug/visualize-mod.js
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+
+const Tool = require('../')
+
+module.exports = {
+  visualize: () => {
+    for (const file of process.argv.slice(2).map(trim)) {
+      const tool = new Tool({ debug: true })
+
+      tool.visualize(
+        file,
+        file + '.html',
+        function (err) {
+          if (err) {
+            throw err
+          } else {
+            console.log('Wrote', file + '.html')
+          }
+        }
+      )
+    }
+  }
+}
+
+function trim (file) {
+  return file.replace(/\/\\$/, '')
+}

--- a/debug/visualize-watch.js
+++ b/debug/visualize-watch.js
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+
+var chokidar = require('chokidar')
+var v = require('./visualize-mod.js')
+
+const debounce = require('lodash.debounce')
+
+// this is useful when updating multiple files in just one go (i.e. checking-out a branch)
+const debVisualize = debounce(v.visualize, 100)
+
+chokidar
+  .watch([
+    'visualizer/**/*.css',
+    'visualizer/**/*.js',
+    'index.js'
+  ], {
+    ignoreInitial: true
+  })
+  .on('all', (event, path) => {
+    console.log(event, path)
+    debVisualize()
+  })
+
+v.visualize()

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "repository": "nearform/node-clinic-doctor",
   "version": "3.5.0",
   "scripts": {
+    "visualize-watch": "node debug/visualize-watch.js",
+    "visualize-all": "node debug/visualize-all.js",
     "test": "standard | snazzy && tap --no-cov test/*.test.js",
     "ci-lint": "standard | snazzy",
     "ci-test": "tap test/*.test.js",
@@ -42,6 +44,7 @@
   },
   "devDependencies": {
     "cheerio": "^1.0.0-rc.2",
+    "chokidar": "^2.0.4",
     "rimraf": "^2.6.2",
     "snazzy": "^8.0.0",
     "standard": "^12.0.0",


### PR DESCRIPTION
Adding the same debug tool we already use on Flame / Bubbleprof to improve the dev experience.
Just `npm run visualize-watch <path>`

the `<path>` could be something like: 
`../node-clinic-doctor-examples/45772.clinic-doctor`
or
`../node-clinic-doctor-examples/*.clinic-doctor`