### PR TITLE
do not abort on process exit code

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,9 +98,9 @@ class ClinicDoctor extends events.EventEmitter {
       // report if the process did not exit normally.
       if (code !== 0 && signal !== 'SIGINT') {
         if (code !== null) {
-          console.error(new Error(`process exited with exit code ${code}`))
+          console.error(`process exited with exit code ${code}`)
         } else {
-          console.error(new Error(`process exited by signal ${signal}`))
+          console.error(`process exited by signal ${signal}`)
         }
       }
 

--- a/index.js
+++ b/index.js
@@ -95,18 +95,12 @@ class ClinicDoctor extends events.EventEmitter {
       /* istanbul ignore next: windows hack */
       if (code === 3221225786 && os.platform() === 'win32') signal = 'SIGINT'
 
-      // Abort if the process did not exit normally.
+      // report if the process did not exit normally.
       if (code !== 0 && signal !== 'SIGINT') {
         if (code !== null) {
-          return callback(
-            new Error(`process exited with exit code ${code}`),
-            paths['/']
-          )
+          console.error(new Error(`process exited with exit code ${code}`))
         } else {
-          return callback(
-            new Error(`process exited by signal ${signal}`),
-            paths['/']
-          )
+          console.error(new Error(`process exited by signal ${signal}`))
         }
       }
 

--- a/test/cmd-collect-exit.test.js
+++ b/test/cmd-collect-exit.test.js
@@ -6,7 +6,6 @@ const path = require('path')
 const async = require('async')
 const { spawn } = require('child_process')
 const endpoint = require('endpoint')
-const CollectAndRead = require('./collect-and-read.js')
 
 test('cmd - collect - external SIGINT is relayed', function (t) {
   if (os.platform() === 'win32') {
@@ -35,31 +34,6 @@ test('cmd - collect - external SIGINT is relayed', function (t) {
     t.ok(output.stderr.toString().split('\n').length, 1)
     t.strictEqual(output.stdout.toString(),
       'listening for SIGINT\nSIGINT received\n')
-    t.end()
-  })
-})
-
-test('cmd - collect - non-success exit code causes error', function (t) {
-  const cmd = new CollectAndRead({}, '--expose-gc', '-e', 'process.exit(1)')
-
-  cmd.once('error', function (err) {
-    cmd.cleanup()
-
-    t.strictDeepEqual(err, new Error('process exited with exit code 1'))
-    t.end()
-  })
-})
-
-test('cmd - collect - non-success exit code causes error', function (t) {
-  const cmd = new CollectAndRead(
-    {},
-    '--expose-gc', '-e', 'process.kill(process.pid, "SIGKILL")'
-  )
-
-  cmd.once('error', function (err) {
-    cmd.cleanup()
-
-    t.strictDeepEqual(err, new Error('process exited with exit signal SIGKILL'))
     t.end()
   })
 })

--- a/test/cmd-collect-exit.test.js
+++ b/test/cmd-collect-exit.test.js
@@ -6,6 +6,7 @@ const path = require('path')
 const async = require('async')
 const { spawn } = require('child_process')
 const endpoint = require('endpoint')
+const CollectAndRead = require('./collect-and-read.js')
 
 test('cmd - collect - external SIGINT is relayed', function (t) {
   if (os.platform() === 'win32') {
@@ -34,6 +35,14 @@ test('cmd - collect - external SIGINT is relayed', function (t) {
     t.ok(output.stderr.toString().split('\n').length, 1)
     t.strictEqual(output.stdout.toString(),
       'listening for SIGINT\nSIGINT received\n')
+    t.end()
+  })
+})
+
+test('cmd - collect - non-success exit code should not throw', function (t) {
+  const cmd = new CollectAndRead({}, '--expose-gc', '-e', 'process.exit(1)')
+  cmd.on('error', t.ifError.bind(t))
+  cmd.on('ready', function () {
     t.end()
   })
 })


### PR DESCRIPTION
Related to issue #189 and nearform/node-clinic#73

Do not throw on client application termination. 
Only report error and continue processing the traces.

Adjusted handler and removed tests that check on error throwing.
