### PR TITLE
Skip SIGKILL test on Windows to fix CI

### DIFF
--- a/test/cmd-collect-exit.test.js
+++ b/test/cmd-collect-exit.test.js
@@ -8,13 +8,11 @@ const { spawn } = require('child_process')
 const endpoint = require('endpoint')
 const CollectAndRead = require('./collect-and-read.js')
 
-test('cmd - collect - external SIGINT is relayed', function (t) {
-  if (os.platform() === 'win32') {
-    t.pass('Skip test as we cannot easily send SIGINT on windows')
-    t.end()
-    return
-  }
+const isWindows = os.platform() === 'win32'
+let skip
 
+skip = isWindows ? 'Skip test as we cannot easily send SIGINT on Windows' : false
+test('cmd - collect - external SIGINT is relayed', { skip }, function (t) {
   const child = spawn(
     process.execPath, [
       path.resolve(__dirname, 'cmd-collect-exit-sigint.script.js')
@@ -47,15 +45,10 @@ test('cmd - collect - non-success exit code should not throw', function (t) {
   })
 })
 
-test('cmd - collect - SIGKILL causes error', function (t) {
-  // On Windows, process.exit(1) and'process.kill(pid, 'SIGKILL') both give exit code 1
-  // TODO: test Windows SIGKILL behaviour, if it should error, find reliable detection
-  if (os.platform() === 'win32') {
-    t.pass('Skip test as SIGKILL also sends exit code 1 on windows')
-    t.end()
-    return
-  }
-
+// On Windows, process.exit(1) and'process.kill(pid, 'SIGKILL') both give exit code 1
+// TODO: test Windows SIGKILL behaviour, if it should error, find reliable detection
+skip = isWindows ? 'Skip test as SIGKILL also sends exit code 1 on Windows' : false
+test('cmd - collect - SIGKILL causes error', { skip }, function (t) {
   const cmd = new CollectAndRead(
     {},
     '--expose-gc', '-e', 'process.kill(process.pid, "SIGKILL")'

--- a/test/cmd-collect-exit.test.js
+++ b/test/cmd-collect-exit.test.js
@@ -47,7 +47,7 @@ test('cmd - collect - non-success exit code should not throw', function (t) {
   })
 })
 
-test('cmd - collect - non-success exit code causes error', function (t) {
+test('cmd - collect - SIGKILL causes error', function (t) {
   const cmd = new CollectAndRead(
     {},
     '--expose-gc', '-e', 'process.kill(process.pid, "SIGKILL")'

--- a/test/cmd-collect-exit.test.js
+++ b/test/cmd-collect-exit.test.js
@@ -48,6 +48,14 @@ test('cmd - collect - non-success exit code should not throw', function (t) {
 })
 
 test('cmd - collect - SIGKILL causes error', function (t) {
+  // On Windows, process.exit(1) and'process.kill(pid, 'SIGKILL') both give exit code 1
+  // TODO: test Windows SIGKILL behaviour, if it should error, find reliable detection
+  if (os.platform() === 'win32') {
+    t.pass('Skip test as SIGKILL also sends exit code 1 on windows')
+    t.end()
+    return
+  }
+
   const cmd = new CollectAndRead(
     {},
     '--expose-gc', '-e', 'process.kill(process.pid, "SIGKILL")'


### PR DESCRIPTION
Quick partial fix for https://github.com/nearform/node-clinic-doctor/issues/194 because AppVeyor has been red for two releases and it's contributing to CITGM failing (issue https://github.com/nearform/node-clinic-doctor/issues/192 )

On Windows, SIGKILL also gives exit code 1, causing our SIGKILL-only test to fail, and there isn't an easy way to distinguish SIGKILL on Windows.