### PR TITLE
Raise test timeout limits

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
   "scripts": {
     "visualize-watch": "node debug/visualize-watch.js",
     "visualize-all": "node debug/visualize-all.js",
-    "test": "standard | snazzy && tap --no-cov test/*.test.js",
+    "test": "standard | snazzy && tap --timeout=50 --no-cov test/*.test.js",
     "ci-lint": "standard | snazzy",
-    "ci-test": "tap test/*.test.js",
-    "ci-cov": "tap --100 test/*.test.js",
+    "ci-test": "tap --timeout=50 test/*.test.js",
+    "ci-cov": "tap --timeout=60 --100 test/*.test.js",
     "lint": "standard --fix | snazzy"
   },
   "dependencies": {


### PR DESCRIPTION
Quick fix for https://github.com/nearform/node-clinic-doctor/issues/196 - hard to say for sure because we're trying to pass tests on an environment we don't control.

We should also try to make the tests run faster, but for now, while we are failing tests on CITGM but not our own CI and we know that timeouts are a factor, this should hopefully solve the immediate problem.

Longer timeouts with coverage because they're slower.