### PR TITLE
Pin mathfn to 1.0.1 to fix test failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "distributions": "^1.1.0",
     "endpoint": "^0.4.5",
     "hidden-markov-model-tf": "^1.2.0",
+    "mathfn": "1.0.1",
     "minify-stream": "^1.2.0",
     "mkdirp": "^0.5.1",
     "node-trace-log-join": "^1.0.0",


### PR DESCRIPTION
[This patch][patch] caused test failures. We don't depend on mathfn
directly, but we depend on `ttest` which depends on `distributions`
which depends on mathfn. `distributions` accepts any 1.x range for
mathfn, so by pinning it to 1.0.1 in Doctor, npm should dedupe it and
pick our version.

[patch]: https://github.com/AndreasMadsen/mathfn/commit/219a7a346bbbef2475f901ca93bfc7e90d0cc86c