### PR TITLE
Upgrade `ttest` and `distributions`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,10 +26,9 @@
     "d3-shape": "^1.2.0",
     "d3-time-format": "^2.1.0",
     "debug": "^4.0.0",
-    "distributions": "1.1.0",
+    "distributions": "^2.0.0",
     "endpoint": "^0.4.5",
     "hidden-markov-model-tf": "^1.2.0",
-    "mathfn": "1.0.1",
     "minify-stream": "^1.2.0",
     "mkdirp": "^0.5.1",
     "node-trace-log-join": "^1.0.0",
@@ -41,7 +40,7 @@
     "stream-template": "0.0.8",
     "streaming-json-stringify": "^3.1.0",
     "summary": "^1.0.0",
-    "ttest": "1.1.0"
+    "ttest": "^2.0.0"
   },
   "devDependencies": {
     "cheerio": "^1.0.0-rc.2",


### PR DESCRIPTION
These now use cephes instead of mathfn.

Closes #200 
Closes #202 
Closes #203 