### PR TITLE
Add implicit dependency lodash.debounce

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   "devDependencies": {
     "cheerio": "^1.0.0-rc.2",
     "chokidar": "^2.0.4",
+    "lodash.debounce": "^4.0.8",
     "rimraf": "^2.6.2",
     "snazzy": "^8.0.0",
     "standard": "^12.0.0",


### PR DESCRIPTION
While checking for any more deprecated deps I found that we have an implicit one - we use lodash.debounce in `/debug/visualize-watch.js` (therefore dev dep) but it's not in package.json