### PR TITLE
Whole alert bar clickable; hover on item highlights appropriate graph

### DIFF
--- a/visualizer/alert.js
+++ b/visualizer/alert.js
@@ -87,6 +87,9 @@ class Alert extends EventEmitter {
       .enter()
       .append('li')
       .on('click', (d) => this.emit('click', d.graphId))
+      .on('mouseover', (d) => this.emit('hover-in', d.graphId))
+      .on('mouseout', (d) => this.emit('hover-out', d.graphId))
+      .append('span')
       .text((d) => d.title)
 
     // Set title text now, such that the width is calculated correctly

--- a/visualizer/alert.js
+++ b/visualizer/alert.js
@@ -31,6 +31,9 @@ class Alert extends EventEmitter {
 
     this.summary = this.container.append('div')
       .classed('summary', true)
+      .on('click', () => {
+        if (this.container.classed('has-issue')) this.emit(this.opened ? 'close' : 'open')
+      })
 
     this.alert = this.summary.append('svg')
       .classed('alert', true)
@@ -44,7 +47,6 @@ class Alert extends EventEmitter {
 
     this.toggle = this.summary.append('div')
       .classed('toggle', true)
-      .on('click', () => this.emit(this.opened ? 'close' : 'open'))
     this.toggle.append('svg')
       .classed('arrow-down', true)
       .call(icons.insertIcon('arrow-down'))

--- a/visualizer/main.js
+++ b/visualizer/main.js
@@ -25,6 +25,12 @@ alert.on('click', function (graphId) {
     behavior: 'smooth'
   })
 })
+alert.on('hover-in', function (graphId) {
+  document.getElementById(graphId).classList.add('highlight')
+})
+alert.on('hover-out', function (graphId) {
+  document.getElementById(graphId).classList.remove('highlight')
+})
 
 graph.on('hover-show', () => graph.hoverShow())
 graph.on('hover-hide', () => graph.hoverHide())

--- a/visualizer/style.css
+++ b/visualizer/style.css
@@ -13,6 +13,7 @@ html {
   --alert-indicator-color: rgb(233, 67, 100);
 
   --menu-button-color: rgb(200, 201, 203);
+  --button-highlight-color: rgb(255, 255, 255);
 
   --graph-text-color: rgb(255, 255, 255);
   --graph-bg-color: rgb(27, 30, 39);
@@ -54,6 +55,7 @@ html.light-theme {
   --alert-button-color: rgb(123, 128, 146);
 
   --menu-button-color: rgb(123, 128, 146);
+  --button-highlight-color: rgb(65, 69, 85);
 
   --graph-text-color: rgb(101, 101, 101);
   --graph-bg-color: rgb(227, 227, 227);
@@ -278,7 +280,7 @@ html.light-theme #front-matter, html.light-theme #graph, html.light-theme #recom
 }
 #alert .summary:hover .toggle svg {
   /* highlight the toggle icon when hoverred, same contrast as text */
-  fill: var(--alert-text-color);
+  fill: var(--button-highlight-color);
   transform: scale(1.15);
 }
 
@@ -326,6 +328,9 @@ html.light-theme #front-matter, html.light-theme #graph, html.light-theme #recom
 
 #menu svg {
   fill: var(--menu-button-color);
+}
+#menu svg:hover {
+  fill: var(--button-highlight-color);
 }
 
 #toggle-grid svg {

--- a/visualizer/style.css
+++ b/visualizer/style.css
@@ -228,6 +228,9 @@ html.light-theme #front-matter, html.light-theme #graph, html.light-theme #recom
   height: 22px;
   align-items: center;
 }
+#alert.has-issue .summary {
+  cursor: pointer;
+}
 
 #alert .summary svg.alert {
   display: none;
@@ -273,6 +276,12 @@ html.light-theme #front-matter, html.light-theme #graph, html.light-theme #recom
 
   fill: var(--alert-button-color);
 }
+#alert .summary:hover .toggle svg {
+  /* highlight the toggle icon when hoverred, same contrast as text */
+  fill: var(--alert-text-color);
+  transform: scale(1.15);
+}
+
 #alert .summary .toggle svg.arrow-down {
   top: -6px;
 }

--- a/visualizer/style.css
+++ b/visualizer/style.css
@@ -300,6 +300,15 @@ html.light-theme #front-matter, html.light-theme #graph, html.light-theme #recom
   cursor: pointer;
 }
 
+#alert ul.details li span {
+  border-bottom: 2px solid transparent;
+  height: 16px;
+  display: inline-block;
+}
+#alert ul.details li:hover span {
+  border-bottom-color: var(--graph-alert-color);
+}
+
 #alert ul.details li::before {
   display: inline-block;
   width: 18px;
@@ -663,8 +672,12 @@ svg#toggle-theme {
 
 #graph .sub-graph .header .title {
   float: left;
-  height: 18px;
+  height: 16px;
   margin-right: 20px;
+  border-bottom: 2px solid transparent;
+}
+#graph .sub-graph.highlight .header .title {
+  border-bottom-color: var(--graph-alert-color);
 }
 
 #graph .sub-graph .header .title svg.alert {


### PR DESCRIPTION
Closes https://github.com/nearform/node-clinic-doctor/issues/173 and deals with some related/knock-on UX issues:

- Makes the whole of the alert bar clickable to expand it, because clicking on the toggle icon is a little fiddly and annoying (fixes https://github.com/nearform/node-clinic-doctor/issues/173)
- However, since there are no visual indications of what is hovered, this means it's unclear if you're mousing over the toggle bar or the list item
  - There's another UX issue here, which is that the click behaviour on a list item - scrolling to the appropriate graph - doesn't work well in the (now-default) grid view. It just scrolls down a few pixels and doesn't give any clue which graph is meant
  - So, commit 2 adds a tiny feature highlighting the list item text and the graph title in the same way, so you can tell which it means.

Before: https://upload.clinicjs.org/public/5e7676afea7d405f23687c69edd9745fc5c0317d6e46984de545cd50b5da57d1/18028.clinic-doctor.html

After: https://upload.clinicjs.org/public/6a040286a3161a6de64508b7366ffa6be3b0d71a9043cdb69dd4ba0935b3dd54/18028.clinic-doctor.html