### PR TITLE
Emit "analysing" event as soon as process exits.

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,7 +89,7 @@ class ClinicDoctor extends events.EventEmitter {
       if (os.platform() !== 'win32') proc.kill('SIGINT')
     })
 
-    proc.once('exit', function (code, signal) {
+    proc.once('exit', (code, signal) => {
       // Windows exit code STATUS_CONTROL_C_EXIT 0xC000013A returns 3221225786
       // if not caught. See https://msdn.microsoft.com/en-us/library/cc704588.aspx
       /* istanbul ignore next */
@@ -108,6 +108,8 @@ class ClinicDoctor extends events.EventEmitter {
           )
         }
       }
+
+      this.emit('analysing')
 
       // move trace_event file to logging directory
       joinTrace(

--- a/test/cmd-collect-analysing.test.js
+++ b/test/cmd-collect-analysing.test.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const fs = require('fs')
-const path = require('path')
 const { test } = require('tap')
 const rimraf = require('rimraf')
 const ClinicDoctor = require('../index.js')

--- a/test/cmd-collect-analysing.test.js
+++ b/test/cmd-collect-analysing.test.js
@@ -1,0 +1,35 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+const { test } = require('tap')
+const rimraf = require('rimraf')
+const ClinicDoctor = require('../index.js')
+
+test('cmd - test collect - emits "analysing" event', function (t) {
+  const tool = new ClinicDoctor()
+
+  function cleanup (err, dirname) {
+    t.ifError(err)
+    t.match(dirname, /^[0-9]+\.clinic-doctor/)
+    rimraf(dirname, (err) => {
+      t.ifError(err)
+      t.end()
+    })
+  }
+
+  let seenAnalysing = false
+  tool.on('analysing', () => {
+    seenAnalysing = true
+  })
+
+  tool.collect(
+    [process.execPath, '-e', 'setTimeout(() => {}, 123)'],
+    function (err, dirname) {
+      if (err) return cleanup(err, dirname)
+
+      t.ok(seenAnalysing) // should've happened before this callback
+      cleanup(null, dirname)
+    }
+  )
+})


### PR DESCRIPTION
for consistency among tools, emit an 'analysing' event when starting the analysis that's done during the collect phase. for doctor and bubbleprof, that's not much (just moving a file).