### PR TITLE
Fix NODE_PATH for legacy projects

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,8 +25,8 @@ const buildCss = require('@nearform/clinic-common/scripts/build-css')
 const mainTemplate = require('@nearform/clinic-common/templates/main')
 
 const makeInjectPath = (fileName) => {
-  return path.join(__dirname, 'injects', fileName);
-};
+  return path.join(__dirname, 'injects', fileName)
+}
 
 class ClinicDoctor extends events.EventEmitter {
   constructor (settings = {}) {
@@ -50,7 +50,7 @@ class ClinicDoctor extends events.EventEmitter {
     // run program, but inject the sampler
     const logArgs = [
       '-r', makeInjectPath('no-cluster.js'),
-      '-r', makeInjectPath('logger.js'),
+      '-r', makeInjectPath('sampler.js'),
       '--trace-events-enabled', '--trace-event-categories', 'v8'
     ]
 

--- a/index.js
+++ b/index.js
@@ -24,9 +24,7 @@ const buildJs = require('@nearform/clinic-common/scripts/build-js')
 const buildCss = require('@nearform/clinic-common/scripts/build-css')
 const mainTemplate = require('@nearform/clinic-common/templates/main')
 
-const makeInjectPath = (fileName) => {
-  return path.join(__dirname, 'injects', fileName)
-}
+const makeInjectPath = fileName => path.join(__dirname, 'injects', fileName)
 
 class ClinicDoctor extends events.EventEmitter {
   constructor (settings = {}) {

--- a/index.js
+++ b/index.js
@@ -24,8 +24,6 @@ const buildJs = require('@nearform/clinic-common/scripts/build-js')
 const buildCss = require('@nearform/clinic-common/scripts/build-css')
 const mainTemplate = require('@nearform/clinic-common/templates/main')
 
-const makeInjectPath = fileName => path.join(__dirname, 'injects', fileName)
-
 class ClinicDoctor extends events.EventEmitter {
   constructor (settings = {}) {
     super()
@@ -47,15 +45,15 @@ class ClinicDoctor extends events.EventEmitter {
   collect (args, callback) {
     // run program, but inject the sampler
     const logArgs = [
-      '-r', makeInjectPath('no-cluster.js'),
-      '-r', makeInjectPath('sampler.js'),
+      '-r', 'no-cluster.js',
+      '-r', 'sampler.js',
       '--trace-events-enabled', '--trace-event-categories', 'v8'
     ]
 
     const stdio = ['inherit', 'inherit', 'inherit']
 
     if (this.detectPort) {
-      logArgs.push('-r', makeInjectPath('detect-port.js'))
+      logArgs.push('-r', 'detect-port.js')
       stdio.push('pipe')
     }
 
@@ -66,6 +64,7 @@ class ClinicDoctor extends events.EventEmitter {
     }
 
     const customEnv = {
+      // use NODE_PATH to work around issues with spaces in inject path
       NODE_PATH,
       NODE_OPTIONS: logArgs.join(' ') + (
         process.env.NODE_OPTIONS ? ' ' + process.env.NODE_OPTIONS : ''

--- a/index.js
+++ b/index.js
@@ -24,6 +24,10 @@ const buildJs = require('@nearform/clinic-common/scripts/build-js')
 const buildCss = require('@nearform/clinic-common/scripts/build-css')
 const mainTemplate = require('@nearform/clinic-common/templates/main')
 
+const makeInjectPath = (fileName) => {
+  return path.join(__dirname, 'injects', fileName);
+};
+
 class ClinicDoctor extends events.EventEmitter {
   constructor (settings = {}) {
     super()
@@ -45,21 +49,19 @@ class ClinicDoctor extends events.EventEmitter {
   collect (args, callback) {
     // run program, but inject the sampler
     const logArgs = [
-      '-r', 'no-cluster.js',
-      '-r', 'sampler.js',
+      '-r', makeInjectPath('no-cluster.js'),
+      '-r', makeInjectPath('logger.js'),
       '--trace-events-enabled', '--trace-event-categories', 'v8'
     ]
 
     const stdio = ['inherit', 'inherit', 'inherit']
 
     if (this.detectPort) {
-      logArgs.push('-r', 'detect-port.js')
+      logArgs.push('-r', makeInjectPath('detect-port.js'))
       stdio.push('pipe')
     }
 
     const customEnv = {
-      // use NODE_PATH to work around issues with spaces in inject path
-      NODE_PATH: path.join(__dirname, 'injects'),
       NODE_OPTIONS: logArgs.join(' ') + (
         process.env.NODE_OPTIONS ? ' ' + process.env.NODE_OPTIONS : ''
       ),

--- a/index.js
+++ b/index.js
@@ -59,7 +59,14 @@ class ClinicDoctor extends events.EventEmitter {
       stdio.push('pipe')
     }
 
+    let NODE_PATH = path.join(__dirname, 'injects')
+    // use NODE_PATH to work around issues with spaces in inject path
+    if (process.env.NODE_PATH) {
+      NODE_PATH += `${process.platform === 'win32' ? ';' : ':'}${process.env.NODE_PATH}`
+    }
+
     const customEnv = {
+      NODE_PATH,
       NODE_OPTIONS: logArgs.join(' ') + (
         process.env.NODE_OPTIONS ? ' ' + process.env.NODE_OPTIONS : ''
       ),

--- a/test/cmd-collect.test.js
+++ b/test/cmd-collect.test.js
@@ -88,14 +88,14 @@ test('cmd - collect - data files have content', function (t) {
       if (err) return t.ifError(err)
 
       // expect time seperation to be 10ms, allow 20ms error
-      const allow = 20 //ms
+      const allow = 20
       const sampleTimes = output.processStat.map((stat) => stat.timestamp)
       const timeSeperation = summary(diff(sampleTimes)).mean()
       t.ok(sampleTimes.length > 0, 'data is outputted')
-      const abs = Math.abs(timeSeperation - 10);
-      const difference = abs - allow;
-      process._rawDebug(abs, difference);
-      t.ok(difference < 0);
+      const abs = Math.abs(timeSeperation - 10)
+      const difference = abs - allow
+      process._rawDebug(abs, difference)
+      t.ok(difference < 0)
 
       t.end()
     })

--- a/test/cmd-collect.test.js
+++ b/test/cmd-collect.test.js
@@ -88,14 +88,10 @@ test('cmd - collect - data files have content', function (t) {
       if (err) return t.ifError(err)
 
       // expect time seperation to be 10ms, allow 20ms error
-      const allow = 20
       const sampleTimes = output.processStat.map((stat) => stat.timestamp)
       const timeSeperation = summary(diff(sampleTimes)).mean()
       t.ok(sampleTimes.length > 0, 'data is outputted')
-      const abs = Math.abs(timeSeperation - 10)
-      const difference = abs - allow
-      process._rawDebug(abs, difference)
-      t.ok(difference < 0)
+      t.ok(Math.abs(timeSeperation - 10) < 20)
 
       t.end()
     })

--- a/test/cmd-collect.test.js
+++ b/test/cmd-collect.test.js
@@ -88,10 +88,14 @@ test('cmd - collect - data files have content', function (t) {
       if (err) return t.ifError(err)
 
       // expect time seperation to be 10ms, allow 20ms error
+      const allow = 20 //ms
       const sampleTimes = output.processStat.map((stat) => stat.timestamp)
       const timeSeperation = summary(diff(sampleTimes)).mean()
       t.ok(sampleTimes.length > 0, 'data is outputted')
-      t.ok(Math.abs(timeSeperation - 10) < 20)
+      const abs = Math.abs(timeSeperation - 10);
+      const difference = abs - allow;
+      process._rawDebug(abs, difference);
+      t.ok(difference < 0);
 
       t.end()
     })


### PR DESCRIPTION
Seems this doesn't matter anymore
https://github.com/nearform/node-clinic-doctor/pull/132

But ths still relates to current state
https://github.com/nearform/node-clinic/issues/148

So there might be changes done to fix NODE_PATH back, for legacy projects.