### PR TITLE
trim guessed interval by 100 ms

### DIFF
--- a/test/analysis-guess-interval.test.js
+++ b/test/analysis-guess-interval.test.js
@@ -8,10 +8,42 @@ test('guess interval - expected data', function (t) {
   for (const noise of [0, 1, 5]) {
     const data = generateProcessStat({
       handles: [3, 3, 3, 3, 3, 13, 13, 13, 13, 13, 13, 13, 3, 3, 3]
-    }, noise)
+    }, noise, 100)
 
     const interval = guessInterval(data)
     t.strictDeepEqual(interval, [5, 12])
+  }
+
+  t.end()
+})
+
+test('guess interval - trims 100 ms from left and right side', function (t) {
+  for (const noise of [0, 1, 5]) {
+    const data = generateProcessStat({
+      handles: [
+        3, 3, 3, 3, 3,
+        13, 13, 13, 13, 13, 13, 13, 13, 13, 13,
+        13, 13, 13, 13, 13, 13, 13,
+        13, 13, 13, 13, 13, 13, 13, 13, 13, 13,
+        3, 3, 3
+      ]
+    }, noise, 10)
+
+    const interval = guessInterval(data)
+    t.strictDeepEqual(interval, [14, 23])
+  }
+
+  t.end()
+})
+
+test('guess interval - overtrim is not possible', function (t) {
+  for (const noise of [0, 1, 5]) {
+    const data = generateProcessStat({
+      handles: [3, 3, 3, 3, 3, 13, 13, 13, 3, 3, 3]
+    }, noise, 10)
+
+    const interval = guessInterval(data)
+    t.strictDeepEqual(interval, [7, 7])
   }
 
   t.end()
@@ -21,7 +53,7 @@ test('guess interval - missing left tail', function (t) {
   for (const noise of [0, 1, 5]) {
     const data = generateProcessStat({
       handles: [3, 3, 3, 3, 3, 13, 13, 13, 13, 13, 13, 13]
-    }, noise)
+    }, noise, 100)
 
     const interval = guessInterval(data)
     t.strictDeepEqual(interval, [5, 12])
@@ -34,7 +66,7 @@ test('guess interval - missing right tail', function (t) {
   for (const noise of [0, 1, 5]) {
     const data = generateProcessStat({
       handles: [13, 13, 13, 13, 13, 3, 3, 3, 3, 3, 3, 3]
-    }, noise)
+    }, noise, 100)
 
     const interval = guessInterval(data)
     t.strictDeepEqual(interval, [0, 5])
@@ -46,7 +78,7 @@ test('guess interval - missing right tail', function (t) {
 test('guess interval - flat data', function (t) {
   const data = generateProcessStat({
     handles: [3, 3, 3, 3, 3, 3, 3, 3]
-  }, 0)
+  }, 0, 100)
 
   const interval = guessInterval(data)
   t.strictDeepEqual(interval, [0, 8])

--- a/test/analysis.test.js
+++ b/test/analysis.test.js
@@ -52,13 +52,13 @@ test('Analysis - pipeline - normal interval', async function (t) {
     const goodCPU = generateProcessStat({
       handles: [3, 3, 3, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 3, 3, 3],
       cpu: [1, 1, 1, 100, 100, 120, 90, 110, 100, 80, 110, 90, 110, 1, 1, 1]
-    }, noise)
+    }, noise, 100)
     const goodMemoryGC = generateTraceEvent([
       'NONE', 'SCA', 'NONE', 'SCA', 'NONE', 'SCA', 'NONE', 'SCA', 'NONE',
       'SCA', 'NONE', 'SCA', 'NONE', 'NONE', 'NONE', 'NONE'
-    ])
+    ], 100)
     t.strictDeepEqual(await getAnalysis(goodCPU, goodMemoryGC), {
-      interval: [ 30, 120 ],
+      interval: [ 300, 1200 ],
       issues: {
         delay: false,
         cpu: false,
@@ -76,9 +76,9 @@ test('Analysis - pipeline - normal interval', async function (t) {
     const badCPU = generateProcessStat({
       handles: [3, 3, 3, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 3, 3, 3],
       cpu: [1, 1, 1, 50, 40, 10, 10, 100, 50, 40, 10, 10, 10, 1, 1, 1]
-    }, noise)
+    }, noise, 100)
     t.strictDeepEqual(await getAnalysis(badCPU, []), {
-      interval: [ 30, 120 ],
+      interval: [ 300, 1200 ],
       issues: {
         delay: false,
         cpu: true,
@@ -101,9 +101,9 @@ test('Analysis - pipeline - full interval', async function (t) {
   const goodCPU = generateProcessStat({
     handles: [3, 3, 3, 3, 3, 3, 3, 3, 3, 3],
     cpu: [100, 100, 120, 90, 110, 100, 80, 110, 90, 110]
-  }, 0)
+  }, 0, 100)
   t.strictDeepEqual(await getAnalysis(goodCPU, []), {
-    interval: [ 0, 90 ],
+    interval: [ 0, 900 ],
     issues: {
       delay: false,
       cpu: false,
@@ -121,10 +121,10 @@ test('Analysis - pipeline - full interval', async function (t) {
   const badCPU = generateProcessStat({
     handles: [3, 3, 3, 3, 3, 3, 3, 3, 3, 3],
     cpu: [50, 40, 10, 10, 100, 50, 40, 10, 10, 10]
-  }, 0)
+  }, 0, 100)
 
   t.strictDeepEqual(await getAnalysis(badCPU, []), {
-    interval: [ 0, 90 ],
+    interval: [ 0, 900 ],
     issues: {
       delay: false,
       cpu: true,

--- a/test/cmd-visualize.test.js
+++ b/test/cmd-visualize.test.js
@@ -25,7 +25,7 @@ test('cmd - test visualization - data exists', function (t) {
   }
 
   tool.collect(
-    [process.execPath, '-e', 'setTimeout(() => {}, 200)'],
+    [process.execPath, '-e', 'setTimeout(() => {}, 400)'],
     function (err, dirname) {
       if (err) return cleanup(err, dirname)
 
@@ -82,7 +82,7 @@ test('cmd - test visualization - memory exhausted', function (t) {
   })
 
   tool.collect(
-    [process.execPath, '-e', 'setTimeout(() => {}, 200)'],
+    [process.execPath, '-e', 'setTimeout(() => {}, 400)'],
     function (err, dirname) {
       if (err) return cleanup(err, dirname)
 

--- a/test/generate-process-stat.js
+++ b/test/generate-process-stat.js
@@ -3,10 +3,17 @@
 const xorshift = require('xorshift')
 const MB = Math.pow(1024, 2)
 
-function generateProcessStat (data, noiseLevel) {
+function generateProcessStat (data, noiseLevel, timeSpaceing) {
   const rng = new xorshift.constructor([
     294915, 70470, 145110, 287911 // from random.org :)
   ])
+
+  if (noiseLevel === undefined) {
+    noiseLevel = 0
+  }
+  if (timeSpaceing === undefined) {
+    timeSpaceing = 10
+  }
 
   function noise () {
     return rng.random() * noiseLevel
@@ -40,7 +47,7 @@ function generateProcessStat (data, noiseLevel) {
   const output = []
   for (let i = 0; i < maxLength; i++) {
     output.push({
-      timestamp: i * 10,
+      timestamp: i * timeSpaceing,
       delay: !flat.delay ? 0 : flat.delay[i] + noise(),
       cpu: !flat.cpu ? 0 : (flat.cpu[i] + noise()) * 0.01,
       memory: {

--- a/test/generate-trace-event.js
+++ b/test/generate-trace-event.js
@@ -6,7 +6,11 @@ const typeMap = new Map([
   ['NONE', null]
 ])
 
-function generateTraceEvent (data) {
+function generateTraceEvent (data, timeSpaceing) {
+  if (timeSpaceing === undefined) {
+    timeSpaceing = 10
+  }
+
   const output = []
 
   let lastType = null
@@ -18,8 +22,8 @@ function generateTraceEvent (data) {
       lastType = type
       startIndex = i
     } else if (type !== lastType) {
-      const startTimestamp = startIndex * 10
-      const endTimestamp = i * 10
+      const startTimestamp = startIndex * timeSpaceing
+      const endTimestamp = i * timeSpaceing
 
       output.push({
         pid: 0,


### PR DESCRIPTION
Sometimes the workload stops just before (40ms) the handles reduces. This cases the guesses interval to contain unwanted data. The unwanted data causes the analysis to produce false positives. 

This trims off 100 ms from both the beginning and the end of the guesses interval.