### PR TITLE
Fix tests on Node.js 13.9.0

### DIFF
--- a/format/process-stat.proto
+++ b/format/process-stat.proto
@@ -10,5 +10,6 @@ message ProcessStat {
     required double heapTotal = 2;
     required double heapUsed = 3;
     required double external = 4;
+    optional double arrayBuffers = 5;
   }
 }


### PR DESCRIPTION
There is now an `arrayBuffers` property on the `process.memoryUsage()` value. This updates the protocol buffers to support it and updates the tests to match.