### PR TITLE
Fix sample collection when using worker threads

### DIFF
--- a/injects/sampler.js
+++ b/injects/sampler.js
@@ -1,22 +1,36 @@
 'use strict'
 
+// Important to keep in mind that every Node.js worker thread
+// will run it's own instance of the sample.js.
+
 const fs = require('fs')
 const makeDir = require('mkdirp')
 const systemInfo = require('../collect/system-info.js')
 const ProcessStat = require('../collect/process-stat.js')
 const getLoggingPaths = require('@nearform/clinic-common').getLoggingPaths('doctor')
 const ProcessStatEncoder = require('../format/process-stat-encoder.js')
+const { isMainThread, threadId } = require('worker_threads')
 
 // create encoding files and directory
 const paths = getLoggingPaths({ path: process.env.NODE_CLINIC_DOCTOR_DATA_PATH, identifier: process.pid })
 
 makeDir.sync(paths['/'])
 
-// write system file
-fs.writeFileSync(paths['/systeminfo'], JSON.stringify(systemInfo(), null, 2))
+// write system file only on the main thread
+if (isMainThread) {
+  fs.writeFileSync(paths['/systeminfo'], JSON.stringify(systemInfo(), null, 2))
+}
 
 const processStatEncoder = new ProcessStatEncoder()
-const out = processStatEncoder.pipe(fs.createWriteStream(paths['/processstat']))
+
+// If sampling in a worker thread, we have to write samples
+// out to a separate processstat file.
+let outpath = paths['/processstat']
+if (!isMainThread) {
+  outpath += `-${threadId}`
+}
+
+const out = processStatEncoder.pipe(fs.createWriteStream(outpath))
 
 // sample every 10ms
 const processStat = new ProcessStat(parseInt(

--- a/test/cmd-collect-analysing-worker.test.js
+++ b/test/cmd-collect-analysing-worker.test.js
@@ -1,0 +1,37 @@
+'use strict'
+
+const { test } = require('tap')
+const rimraf = require('rimraf')
+const ClinicDoctor = require('../index.js')
+
+test('cmd - test collect - emits "analysing" event', function (t) {
+  const tool = new ClinicDoctor()
+
+  function cleanup (err, dirname) {
+    t.ifError(err)
+    t.match(dirname, /^[0-9]+\.clinic-doctor/)
+    rimraf(dirname, (err) => {
+      t.ifError(err)
+      t.end()
+    })
+  }
+
+  let seenAnalysing = false
+  tool.on('analysing', () => {
+    seenAnalysing = true
+  })
+
+  const expr = 'setTimeout(() => {}, 123);' +
+               'const { Worker } = require("worker_threads");' +
+               'new Worker("setTimeout(() => {}, 123);", { eval: true });'
+
+  tool.collect(
+    [process.execPath, '-e', expr],
+    function (err, dirname) {
+      if (err) return cleanup(err, dirname)
+
+      t.ok(seenAnalysing) // should've happened before this callback
+      cleanup(null, dirname)
+    }
+  )
+})


### PR DESCRIPTION
When sampler.js is running in a worker thread, redirect processstat to a different file and suppress the systeminfo file.

@goto-bus-stop .. in my local environment I'm seeing a failure in certain tests that do not appear to be directly related but might be...

```
 PASS  test/analysis-cpu.test.js 40 OK 1s
 PASS  test/analysis-delay.test.js 8 OK 45.155ms
 PASS  test/analysis-guess-interval.test.js 16 OK 56.536ms
 PASS  test/analysis-handles.test.js 12 OK 50.897ms
 PASS  test/analysis-issue-category.test.js 20 OK 27.577ms
 PASS  test/analysis-memory.test.js 11 OK 93.541ms
 PASS  test/analysis.test.js 10 OK 1s
 PASS  test/cmd-collect-analysing-worker.test.js 4 OK 587.209ms
 PASS  test/cmd-collect-analysing.test.js 4 OK 440.233ms
 PASS  test/cmd-collect-detect-port.test.js 6 OK 600.236ms
test/cmd-collect-exit.test.js 2> process exited with exit code 1
 SKIP  test/cmd-collect-exit.test.js
 ~ cmd - collect - external SIGINT is relayed > Skip test as we cannot easily send SIGINT on Windows

 SKIP  test/cmd-collect-exit.test.js
 ~ cmd - collect - SIGKILL causes error > Skip test as SIGKILL also sends exit code 1 on Windows

 SKIP  test/cmd-collect-exit.test.js 2 skip of 3 392.024ms
 ~ cmd - collect - external SIGINT is relayed > Skip test as we cannot easily send SIGINT on Windows
 ~ cmd - collect - SIGKILL causes error > Skip test as SIGKILL also sends exit code 1 on Windows

 PASS  test/cmd-collect-node-options-env.test.js 2 OK 2s
 PASS  test/cmd-collect-node-path-env.test.js 2 OK 2s
 PASS  test/cmd-collect-sample-interval.test.js 2 OK 1s
 PASS  test/cmd-collect.test.js 11 OK 2s
 PASS  test/cmd-no-cluster.test.js 3 OK 3s
 FAIL  test/cmd-visualize.test.js 1230 OK 50s
  command: C:\Users\jasne\AppData\Local\nvs\node\13.11.0\x64\node.exe
  args:
    - -r
    - C:\Users\jasne\Projects\clinic\node-clinic-doctor\node_modules\esm\esm.js
    - test/cmd-visualize.test.js
  exitCode: null
  signal: SIGTERM

 PASS  test/collect-get-logging-paths.test.js 8 OK 84.679ms
 PASS  test/collect-process-stat.test.js 10 OK 496.138ms
 PASS  test/collect-system-info.test.js 5 OK 27.585ms
 PASS  test/format-process-stat.test.js 9 OK 49.158ms
 PASS  test/format-system-info.test.js 1 OK 36.129ms
 PASS  test/format-trace-event.test.js 2 OK 44.636ms
 PASS  test/lib-destroyable-stream.test.js 20 OK 46.163ms
 PASS  test/recommendation.test.js 62 OK 224.213ms
```