### PR TITLE
Use `trace_events` module instead of Node.js CLI flags

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,8 +48,7 @@ class ClinicDoctor extends events.EventEmitter {
     // run program, but inject the sampler
     const logArgs = [
       '-r', 'no-cluster.js',
-      '-r', 'sampler.js',
-      '--trace-events-enabled', '--trace-event-categories', 'v8'
+      '-r', 'sampler.js'
     ]
 
     const stdio = ['inherit', 'inherit', 'inherit']

--- a/injects/sampler.js
+++ b/injects/sampler.js
@@ -2,6 +2,7 @@
 
 const fs = require('fs')
 const makeDir = require('mkdirp')
+const traceEvents = require('trace_events')
 const systemInfo = require('../collect/system-info.js')
 const ProcessStat = require('../collect/process-stat.js')
 const getLoggingPaths = require('@nearform/clinic-common').getLoggingPaths('doctor')
@@ -14,6 +15,10 @@ makeDir.sync(paths['/'])
 
 // write system file
 fs.writeFileSync(paths['/systeminfo'], JSON.stringify(systemInfo(), null, 2))
+
+const tracing = traceEvents.createTracing({
+  categories: ['v8']
+})
 
 const processStatEncoder = new ProcessStatEncoder()
 const out = processStatEncoder.pipe(fs.createWriteStream(paths['/processstat']))
@@ -39,10 +44,20 @@ function saveSample () {
 }
 
 // allow time delay to be specified before we start collecting data
-setTimeout(() => {
-  processStat.refresh()
-  scheduleSample()
-}, process.env.NODE_CLINIC_DOCTOR_TIMEOUT_DELAY)
+function start () {
+  tracing.enable()
+  process.nextTick(() => {
+    processStat.refresh()
+    scheduleSample()
+  })
+}
+
+const delay = parseInt(process.env.NODE_CLINIC_DOCTOR_TIMEOUT_DELAY || '0', 10)
+if (delay > 0) {
+  setTimeout(start, delay)
+} else {
+  start()
+}
 
 // before process exits, flush the encoded data to the sample file
 process.once('beforeExit', function () {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "ttest": "^2.0.0"
   },
   "devDependencies": {
+    "atomic-sleep": "^1.0.0",
     "cheerio": "^1.0.0-rc.2",
     "chokidar": "^3.0.0",
     "lodash.debounce": "^4.0.8",

--- a/test/cmd-collect-delay.test.js
+++ b/test/cmd-collect-delay.test.js
@@ -1,0 +1,28 @@
+'use strict'
+
+const test = require('tap').test
+const endpoint = require('endpoint')
+const CollectAndRead = require('./collect-and-read.js')
+
+test('cmd - collect - delay', function (t) {
+  const cmd = new CollectAndRead({ collectDelay: 300 }, '-e', `
+    const sleep = require('atomic-sleep')
+    setTimeout(function () {
+      sleep(200)
+
+      // keep process going for a while so we can collect stats
+      setTimeout(function () {}, 500)
+    }, 0)
+  `)
+
+  cmd.on('ready', function () {
+    cmd.processStat.pipe(endpoint({ objectMode: true }, onprocessstat))
+  })
+
+  function onprocessstat (err, stats) {
+    t.ifError(err)
+    const highestDelay = stats.reduce((acc, stat) => Math.max(acc, stat.delay), 0)
+    t.ok(highestDelay < 100, 'should not have measured the 200ms event loop delay')
+    t.end()
+  }
+})


### PR DESCRIPTION
This will allow us to start collecting trace data after a timeout with `--collect-delay`.

When no timeout is given, it starts collecting trace data immediately, like before.