### PR TITLE
Improve "Jump to section" menu

### DIFF
--- a/visualizer/recommendation.js
+++ b/visualizer/recommendation.js
@@ -64,7 +64,7 @@ class Recomendation extends EventEmitter {
       .classed('menu', true)
     this.content = this.details.append('div')
       .classed('content', true)
-      // .on('scroll.scroller', () => this._drawSelectedArticleMenu())
+      .on('wheel', () => this.clearArticleMenuSelected())
     this.summaryTitle = this.content.append('div')
       .classed('summary-title', true)
     this.summary = this.content.append('div')
@@ -205,6 +205,7 @@ class Recomendation extends EventEmitter {
       this.articleMenu.append('h2')
         .text('Jump to section')
 
+      const self = this
       this.articleMenu.append('ul')
         .selectAll('li')
         .data(this.readMoreArticle.selectAll('h2').nodes())
@@ -215,7 +216,7 @@ class Recomendation extends EventEmitter {
         .on('click', function (headerElement) {
           const elementId = headerElement.textContent.replace(/\s/g, '')
           const selected = d3.select('#' + elementId)
-          d3.select('.article-menu').select('ul').selectAll('li').classed('selected', false)
+          self.clearArticleMenuSelected()
           selected.classed('selected', true)
           headerElement.scrollIntoView({ behavior: 'smooth', block: 'start' })
         })
@@ -224,6 +225,10 @@ class Recomendation extends EventEmitter {
     // set space height such that the fixed element don't have to hide
     // something in the background.
     this.space.style('height', this.details.node().offsetHeight + 'px')
+  }
+
+  clearArticleMenuSelected () {
+    d3.select('.article-menu').select('ul').selectAll('li').classed('selected', false)
   }
 
   openPanel () {

--- a/visualizer/recommendation.js
+++ b/visualizer/recommendation.js
@@ -205,7 +205,6 @@ class Recomendation extends EventEmitter {
       this.articleMenu.append('h2')
         .text('Jump to section')
 
-      const self = this
       this.articleMenu.append('ul')
         .selectAll('li')
         .data(this.readMoreArticle.selectAll('h2').nodes())
@@ -213,10 +212,10 @@ class Recomendation extends EventEmitter {
         .append('li')
         .text((headerElement) => headerElement.textContent)
         .attr('id', (headerElement) => headerElement.textContent.replace(/\s/g, ''))
-        .on('click', function (headerElement) {
+        .on('click', (headerElement) => {
           const elementId = headerElement.textContent.replace(/\s/g, '')
           const selected = d3.select('#' + elementId)
-          self.clearArticleMenuSelected()
+          this.clearArticleMenuSelected()
           selected.classed('selected', true)
           headerElement.scrollIntoView({ behavior: 'smooth', block: 'start' })
         })

--- a/visualizer/recommendation.js
+++ b/visualizer/recommendation.js
@@ -64,7 +64,7 @@ class Recomendation extends EventEmitter {
       .classed('menu', true)
     this.content = this.details.append('div')
       .classed('content', true)
-      .on('scroll.scroller', () => this._drawSelectedArticleMenu())
+      //.on('scroll.scroller', () => this._drawSelectedArticleMenu())
     this.summaryTitle = this.content.append('div')
       .classed('summary-title', true)
     this.summary = this.content.append('div')
@@ -204,43 +204,26 @@ class Recomendation extends EventEmitter {
 
       this.articleMenu.append('h2')
         .text('Jump to section')
-
+      
       this.articleMenu.append('ul')
         .selectAll('li')
         .data(this.readMoreArticle.selectAll('h2').nodes())
         .enter()
         .append('li')
         .text((headerElement) => headerElement.textContent)
+        .attr('id', (headerElement) => headerElement.textContent.replace(/\s/g, ''))
         .on('click', function (headerElement) {
+          const elementId = headerElement.textContent.replace(/\s/g, '')
+          const selected = d3.select('#'+elementId)
+          d3.select('.article-menu').select('ul').selectAll('li').classed('selected', false)
+          selected.classed('selected', true)
           headerElement.scrollIntoView({ behavior: 'smooth', block: 'start' })
         })
-
-      this._drawSelectedArticleMenu()
     }
 
     // set space height such that the fixed element don't have to hide
     // something in the background.
     this.space.style('height', this.details.node().offsetHeight + 'px')
-  }
-
-  _drawSelectedArticleMenu () {
-    const contentScrollTop = this.content.node().scrollTop
-    const contentClientHeight = this.content.node().clientHeight
-
-    function isAboveScrollBottom (headerElement) {
-      const elementBottom = headerElement.offsetTop + headerElement.clientHeight
-      const relativeTopPosition = elementBottom - contentScrollTop
-      return relativeTopPosition <= contentClientHeight
-    }
-
-    const selection = this.articleMenu.select('ul').selectAll('li')
-    const mostRecentHeader = selection.data()
-      .filter(isAboveScrollBottom)
-      .pop()
-
-    selection.classed('selected', function (headerElement) {
-      return headerElement === mostRecentHeader
-    })
   }
 
   openPanel () {

--- a/visualizer/recommendation.js
+++ b/visualizer/recommendation.js
@@ -64,7 +64,7 @@ class Recomendation extends EventEmitter {
       .classed('menu', true)
     this.content = this.details.append('div')
       .classed('content', true)
-      //.on('scroll.scroller', () => this._drawSelectedArticleMenu())
+      // .on('scroll.scroller', () => this._drawSelectedArticleMenu())
     this.summaryTitle = this.content.append('div')
       .classed('summary-title', true)
     this.summary = this.content.append('div')
@@ -204,7 +204,7 @@ class Recomendation extends EventEmitter {
 
       this.articleMenu.append('h2')
         .text('Jump to section')
-      
+
       this.articleMenu.append('ul')
         .selectAll('li')
         .data(this.readMoreArticle.selectAll('h2').nodes())
@@ -214,7 +214,7 @@ class Recomendation extends EventEmitter {
         .attr('id', (headerElement) => headerElement.textContent.replace(/\s/g, ''))
         .on('click', function (headerElement) {
           const elementId = headerElement.textContent.replace(/\s/g, '')
-          const selected = d3.select('#'+elementId)
+          const selected = d3.select('#' + elementId)
           d3.select('.article-menu').select('ul').selectAll('li').classed('selected', false)
           selected.classed('selected', true)
           headerElement.scrollIntoView({ behavior: 'smooth', block: 'start' })


### PR DESCRIPTION
Raised during UI/UX review:

> For Doctor, "Jump to section is fiddly. If I click on Next steps, it'll go through it and end up to reference"

![image](https://user-images.githubusercontent.com/4488048/78776540-e8b9db00-798f-11ea-8b05-cced6807f8d4.png)

1. Improved selection logic. (DONE)
2. Clear selection on scroll. (DONE)
3. Maybe select the first one by default? (Not sure)
