### PR TITLE
Remove read less link to simplify UI

### DIFF
--- a/visualizer/recommendation.js
+++ b/visualizer/recommendation.js
@@ -128,7 +128,7 @@ class Recomendation extends EventEmitter {
 
     this.menu.append('svg')
       .classed('close', true)
-      .on('click', () => this.emit('close-panel'))
+      .on('click', () => this.closeFullscreen())
       .call(icons.insertIcon('close'))
 
     this.bar = this.container.append('div')
@@ -242,6 +242,14 @@ class Recomendation extends EventEmitter {
 
   closePanel () {
     this.panelOpened = false
+  }
+
+  closeFullscreen () {
+    if (this.readMoreOpened) {
+      this.emit('close-read-more')
+    } else {
+      this.emit('close-panel')
+    }
   }
 
   openReadMore () {

--- a/visualizer/recommendation.js
+++ b/visualizer/recommendation.js
@@ -128,6 +128,11 @@ class Recomendation extends EventEmitter {
 
     this.menu.append('svg')
       .classed('close', true)
+      .on('click', () => this.minimize())
+      .call(icons.insertIcon('arrow-down'))
+
+    this.menu.append('svg')
+      .classed('close', true)
       .on('click', () => this.closeFullscreen())
       .call(icons.insertIcon('close'))
 
@@ -244,12 +249,12 @@ class Recomendation extends EventEmitter {
     this.panelOpened = false
   }
 
+  minimize () {
+    this.emit('close-read-more')
+  }
+
   closeFullscreen () {
-    if (this.readMoreOpened) {
-      this.emit('close-read-more')
-    } else {
-      this.emit('close-panel')
-    }
+    this.emit('close-panel')
   }
 
   openReadMore () {

--- a/visualizer/recommendation.js
+++ b/visualizer/recommendation.js
@@ -126,13 +126,6 @@ class Recomendation extends EventEmitter {
       .append('svg')
       .call(icons.insertIcon('arrow-down'))
 
-    const readLessText = this.readMoreButton.append('span')
-      .classed('read-more-button-text read-more-button-text-less', true)
-      .text('Read less')
-    readLessText
-      .append('svg')
-      .call(icons.insertIcon('arrow-up'))
-
     this.menu.append('svg')
       .classed('close', true)
       .on('click', () => this.emit('close-panel'))


### PR DESCRIPTION
Raised in UI/UX review:
>For Doctor, "Read less ^" in full screen view is oddly placed and confusing.

I have removed the link from this area as you can still close via the large "x" button. (top right) Section looks much more clear without the read less link.

![image](https://user-images.githubusercontent.com/4488048/78885758-0c932480-7a55-11ea-89b8-14f63d46d969.png)
