### PR TITLE
Toggle icons for display mode

### DIFF
--- a/visualizer/icons.js
+++ b/visualizer/icons.js
@@ -48,7 +48,8 @@ class Icons {
       close: sanitizeIcon(require('@nearform/clinic-common/icons/close')),
       'grid-1x4': sanitizeIcon(require('@nearform/clinic-common/icons/list-view')),
       'grid-2x2': sanitizeIcon(require('@nearform/clinic-common/icons/grid-view')),
-      theme: sanitizeIcon(require('@nearform/clinic-common/icons/eye-show')),
+      lightmode: sanitizeIcon(require('@nearform/clinic-common/icons/light-mode')),
+      darkmode: sanitizeIcon(require('@nearform/clinic-common/icons/dark-mode')),
       warning: sanitizeIcon(require('@nearform/clinic-common/icons/warning-triangle'))
     }
 

--- a/visualizer/main.js
+++ b/visualizer/main.js
@@ -15,7 +15,7 @@ const drawUi = () => {
   document.body.classList.add('is-font-loaded')
 
   menu.on('toggle-theme', function () {
-    document.documentElement.classList.toggle('toggle-theme')
+    document.documentElement.classList.toggle('light-theme')
   })
 
   menu.on('toggle-grid', function () {

--- a/visualizer/main.js
+++ b/visualizer/main.js
@@ -15,7 +15,7 @@ const drawUi = () => {
   document.body.classList.add('is-font-loaded')
 
   menu.on('toggle-theme', function () {
-    document.documentElement.classList.toggle('light-theme')
+    document.documentElement.classList.toggle('toggle-theme')
   })
 
   menu.on('toggle-grid', function () {

--- a/visualizer/menu.js
+++ b/visualizer/menu.js
@@ -29,16 +29,16 @@ class Menu extends EventEmitter {
 
   setupThemeToggle () {
     const themeButton = this.container.append('div')
-    .classed('toggle', true)
-    .attr('id', 'toggle-theme')
-    .on('click', () => this.emit('toggle-theme'))
+      .classed('toggle', true)
+      .attr('id', 'toggle-theme')
+      .on('click', () => this.emit('toggle-theme'))
 
     themeButton.append('svg')
-      .classed('theme-light', true)
+      .classed('theme-dark', true)
       .call(icons.insertIcon('lightmode'))
     themeButton.append('svg')
-    .classed('theme-dark', true)
-    .call(icons.insertIcon('darkmode'))
+      .classed('theme-light', true)
+      .call(icons.insertIcon('darkmode'))
   }
 }
 

--- a/visualizer/menu.js
+++ b/visualizer/menu.js
@@ -28,11 +28,17 @@ class Menu extends EventEmitter {
   }
 
   setupThemeToggle () {
-    this.container.append('svg')
-      .classed('toggle', true)
-      .attr('id', 'toggle-theme')
-      .on('click', () => this.emit('toggle-theme'))
-      .call(icons.insertIcon('theme'))
+    const themeButton = this.container.append('div')
+    .classed('toggle', true)
+    .attr('id', 'toggle-theme')
+    .on('click', () => this.emit('toggle-theme'))
+
+    themeButton.append('svg')
+      .classed('theme-light', true)
+      .call(icons.insertIcon('lightmode'))
+    themeButton.append('svg')
+    .classed('theme-dark', true)
+    .call(icons.insertIcon('darkmode'))
   }
 }
 

--- a/visualizer/menu.js
+++ b/visualizer/menu.js
@@ -30,7 +30,7 @@ class Menu extends EventEmitter {
   setupThemeToggle () {
     const themeButton = this.container.append('div')
       .classed('toggle', true)
-      .attr('id', 'toggle-theme')
+      .attr('id', 'light-theme')
       .on('click', () => this.emit('toggle-theme'))
 
     themeButton.append('svg')

--- a/visualizer/style.css
+++ b/visualizer/style.css
@@ -313,7 +313,8 @@ html.toggle-theme #front-matter, html.toggle-theme #graph, html.toggle-theme #re
   fill: var(--button-highlight-color);
 }
 
-#toggle-grid svg {
+#toggle-grid svg, 
+#toggle-theme svg {
   height: 18px;
   width: 18px;
 }

--- a/visualizer/style.css
+++ b/visualizer/style.css
@@ -45,7 +45,7 @@ html {
   --article-menu-color: rgb(27, 30, 39);
 }
 
-html.toggle-theme {
+html.light-theme {
   --main-bg-color: rgb(239, 239, 239);
 
   --nc-colour-header-background: rgb(65, 69, 85);
@@ -187,7 +187,7 @@ html .nc-header, html #front-matter, html #graph, html #graph .hover text, html 
   -moz-osx-font-smoothing: grayscale;
 }
 
-html.toggle-theme #front-matter, html.toggle-theme #graph, html.toggle-theme #recommendation .details {
+html.light-theme #front-matter, html.light-theme #graph, html.light-theme #recommendation .details {
   -webkit-font-smoothing: unset;
   -moz-osx-font-smoothing: unset;
 }
@@ -314,7 +314,7 @@ html.toggle-theme #front-matter, html.toggle-theme #graph, html.toggle-theme #re
 }
 
 #toggle-grid svg, 
-#toggle-theme svg {
+#light-theme svg {
   height: 18px;
   width: 18px;
 }
@@ -325,11 +325,11 @@ html.toggle-theme #front-matter, html.toggle-theme #graph, html.toggle-theme #re
   padding: 1px;
 }
 
-html:not(.toggle-theme) #toggle-theme svg.theme-light {
+html:not(.light-theme) #light-theme svg.theme-light {
   display: none;
 }
 
-html.toggle-theme #toggle-theme svg.theme-dark {
+html.light-theme #light-theme svg.theme-dark {
   display: none;
 }
 

--- a/visualizer/style.css
+++ b/visualizer/style.css
@@ -45,7 +45,7 @@ html {
   --article-menu-color: rgb(27, 30, 39);
 }
 
-html.light-theme {
+html.toggle-theme {
   --main-bg-color: rgb(239, 239, 239);
 
   --nc-colour-header-background: rgb(65, 69, 85);
@@ -187,7 +187,7 @@ html .nc-header, html #front-matter, html #graph, html #graph .hover text, html 
   -moz-osx-font-smoothing: grayscale;
 }
 
-html.light-theme #front-matter, html.light-theme #graph, html.light-theme #recommendation .details {
+html.toggle-theme #front-matter, html.toggle-theme #graph, html.toggle-theme #recommendation .details {
   -webkit-font-smoothing: unset;
   -moz-osx-font-smoothing: unset;
 }
@@ -322,6 +322,14 @@ html.light-theme #front-matter, html.light-theme #graph, html.light-theme #recom
   height: 22px;
   width: 22px;
   padding: 1px;
+}
+
+html:not(.toggle-theme) #toggle-theme svg.theme-light {
+  display: none;
+}
+
+html.toggle-theme #toggle-theme svg.theme-dark {
+  display: none;
 }
 
 html:not(.grid-layout) #toggle-grid svg.grid-1x4 {


### PR DESCRIPTION
Raised during the UI/UX review:

> For Doctor, Eye icon for toggling display mode may not be the most appropriate choice.

I have replaced the static eye icon with both a light-mode and dark-mode icon. These icons will toggle when the button is clicked.

When in Dark mode:
![image](https://user-images.githubusercontent.com/4488048/78984477-39f7d500-7b1e-11ea-8fce-641c4b6e3e27.png)

When in Light mode:
![image](https://user-images.githubusercontent.com/4488048/78984505-4aa84b00-7b1e-11ea-9653-901b3a903e35.png)
