### PR TITLE
Full descriptions as tooltips

### DIFF
--- a/visualizer/graph.js
+++ b/visualizer/graph.js
@@ -29,6 +29,11 @@ class Graph extends EventEmitter {
       unit: 'MB',
       longLegend: ['RSS', 'Total Heap Allocated', 'Heap Used'],
       shortLegend: ['RSS', 'THA', 'HU'],
+      tooltipLegend: [
+        'Total memory allocated for the entire process',
+        'Amount of V8 memory assigned to store data',
+        'Heap memory used out of the Total Heap'
+      ],
       showLegend: true,
       lineStyle: ['1, 2', '5, 3', ''],
       numLines: 3,

--- a/visualizer/sub-graph.js
+++ b/visualizer/sub-graph.js
@@ -67,7 +67,7 @@ class SubGraph extends EventEmitter {
 
         legendItem.append('span')
           .classed('long-legend', true)
-          .attr('title', this.setup.longLegend[i])
+          .attr('title', this.setup.tooltipLegend[i])
           .text(this.setup.longLegend[i])
         legendItem.append('span')
           .classed('short-legend', true)


### PR DESCRIPTION
Raised in UI/UX review:
> For Doctor, provide definitions of RSS, THA and HU on hover.

I have provided full text for these tooltips. Open to suggestions on the descriptions:

RSS - 'Total memory allocated for the entire process'.
Total Heap Allocated -  'Amount of V8 memory assigned to store data'.
Heap Used - 'Heap memory used out of the Total Heap'.

![image](https://user-images.githubusercontent.com/4488048/79000240-28292880-7b44-11ea-88ec-482f9019b096.png)