### PR TITLE
In the case of no data display the recommendation instantly

### DIFF
--- a/visualizer/recommendation.js
+++ b/visualizer/recommendation.js
@@ -183,7 +183,7 @@ class Recomendation extends EventEmitter {
 
     const recommendation = this.recommendations.get(this.selectedCategory)
     // In the case of no data display the recommendation instantly
-    if(recommendation.detected && recommendation.category === 'data') {
+    if (recommendation.detected && recommendation.category === 'data') {
       this.panelOpened = true
     }
 

--- a/visualizer/recommendation.js
+++ b/visualizer/recommendation.js
@@ -182,6 +182,10 @@ class Recomendation extends EventEmitter {
       .classed('has-read-more', (d) => d.hasReadMore())
 
     const recommendation = this.recommendations.get(this.selectedCategory)
+    // In the case of no data display the recommendation instantly
+    if(recommendation.detected && recommendation.category === 'data') {
+      this.panelOpened = true
+    }
 
     // update state classes
     this.container


### PR DESCRIPTION
Raised in UI/UX review:

> For Doctor, if data collection or analysis has failed (e.g. "Detected data analysis issue") the error message should be more prevalent along with clear instructions on what user should do next.

Now I'm showing the recommendation panel for cases of no data. This shows helpful information about the problem.

![image](https://user-images.githubusercontent.com/4488048/79329727-372b2480-7f10-11ea-9fcb-f1b663495348.png)
