### PR TITLE
Display doctor version beneath logo

### DIFF
--- a/index.js
+++ b/index.js
@@ -218,6 +218,8 @@ class ClinicDoctor extends events.EventEmitter {
     const nearFormLogoFile = fs.createReadStream(nearFormLogoPath)
     const clinicFaviconBase64 = fs.createReadStream(clinicFaviconPath)
 
+    const doctorVersion = require('./package.json').version
+
     // build JS
     let scriptFile = buildJs({
       basedir: __dirname,
@@ -267,6 +269,7 @@ class ClinicDoctor extends events.EventEmitter {
       headerLogoTitle: 'Clinic Doctor on Clinicjs.org',
       headerLogo: logoFile,
       headerText: 'Doctor',
+      toolVersion: doctorVersion,
       nearFormLogo: nearFormLogoFile,
       uploadId: outputFilename.split('/').pop().split('.html').shift(),
       body


### PR DESCRIPTION
Pass the tool version to the html template.

<img width="487" alt="Screenshot 2020-04-30 at 16 24 22" src="https://user-images.githubusercontent.com/43864112/80728636-11e90980-8aff-11ea-8991-84525c330c69.png">

[Issue FK02](https://trello.com/c/vgIgBXME/843-fk02-visibility-of-system-status)